### PR TITLE
Dismiss checkout web view on cancellation

### DIFF
--- a/Sources/Afterpay/CheckoutViewController.swift
+++ b/Sources/Afterpay/CheckoutViewController.swift
@@ -61,10 +61,10 @@ final class CheckoutViewController: UIViewController, WKNavigationDelegate {
     let status = navigationAction.request.url.flatMap(Status.init(url:))
 
     switch status {
-    case .some(.cancelled):
+    case .cancelled:
       decisionHandler(.cancel)
       dismiss(animated: true, completion: nil)
-    case .none:
+    case nil:
       decisionHandler(.allow)
     }
   }


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T06:17:02Z" title="Tuesday, July 7th 2020, 4:17:02 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T06:30:08Z" title="Tuesday, July 7th 2020, 4:30:08 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="adamjcampbell" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/adamjcampbell) **Authored by [adamjcampbell](https://github.com/adamjcampbell)**
_<time datetime="2020-06-17T06:43:58Z" title="Wednesday, June 17th 2020, 4:43:58 pm +10:00">Jun 17, 2020</time>_
_Merged <time datetime="2020-06-17T07:05:01Z" title="Wednesday, June 17th 2020, 5:05:01 pm +10:00">Jun 17, 2020</time>_
---

<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/ittybittyapps/afterpay-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Make `CheckoutViewController` the delegate of it's `WKWebView`
- Add a `Status` enum that can be constructed from a `URL`
- If the status is `.cancelled` when navigating, cancel the navigation and `dismiss` the webview

![2020-06-17 16 27 04](https://user-images.githubusercontent.com/5327203/84864218-aad8e180-b0b9-11ea-877c-58cb7fb53d0f.gif)
