### PR TITLE
Allow drag to dismiss only after using a confirmation action sheet

### DIFF
--- a/Sources/Afterpay/CheckoutViewController.swift
+++ b/Sources/Afterpay/CheckoutViewController.swift
@@ -9,7 +9,12 @@
 import UIKit
 import WebKit
 
-final class CheckoutViewController: UIViewController, WKNavigationDelegate {
+// swiftlint:disable:next colon
+final class CheckoutViewController:
+  UIViewController,
+  UIAdaptivePresentationControllerDelegate,
+  WKNavigationDelegate
+{ // swiftlint:disable:this opening_brace
 
   private let checkoutUrl: URL
   private let successHandler: (_ token: String) -> Void
@@ -32,8 +37,30 @@ final class CheckoutViewController: UIViewController, WKNavigationDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    presentationController?.delegate = self
+
     webView.navigationDelegate = self
     webView.load(URLRequest(url: checkoutUrl))
+  }
+
+  // MARK: UIAdaptivePresentationControllerDelegate
+
+  func presentationControllerShouldDismiss(
+    _ presentationController: UIPresentationController
+  ) -> Bool {
+    let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+    let dismiss: (UIAlertAction) -> Void = { _ in self.dismiss(animated: true, completion: nil) }
+
+    let actions = [
+      UIAlertAction(title: "Discard Payment", style: .destructive, handler: dismiss),
+      UIAlertAction(title: "Cancel", style: .cancel, handler: nil),
+    ]
+
+    actions.forEach(actionSheet.addAction)
+
+    present(actionSheet, animated: true, completion: nil)
+
+    return false
   }
 
   // MARK: WKNavigationDelegate


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T06:17:09Z" title="Tuesday, July 7th 2020, 4:17:09 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T06:30:15Z" title="Tuesday, July 7th 2020, 4:30:15 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="adamjcampbell" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/adamjcampbell) **Authored by [adamjcampbell](https://github.com/adamjcampbell)**
_<time datetime="2020-06-19T05:52:19Z" title="Friday, June 19th 2020, 3:52:19 pm +10:00">Jun 19, 2020</time>_
_Merged <time datetime="2020-06-19T06:13:13Z" title="Friday, June 19th 2020, 4:13:13 pm +10:00">Jun 19, 2020</time>_
---

<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/ittybittyapps/afterpay-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Makes `CheckoutViewController` conform to `UIAdaptivePresentationControllerDelegate`
- Implements `presentationControllerShouldDismiss` in order to prevent dismissal
- Shows an action sheet when attempting to drag to dismiss

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

SwiftLint doesn't like formatting classes nicely

## Preview

![2020-06-19 15 41 47](https://user-images.githubusercontent.com/5327203/85101033-d0462680-b244-11ea-81dc-d3a8319a06a6.gif)
