### PR TITLE
Set allowsLinkPreview to false to disable preview pop-overs

### DIFF
--- a/Sources/Afterpay/WebViewController.swift
+++ b/Sources/Afterpay/WebViewController.swift
@@ -45,6 +45,7 @@ final class WebViewController:
 
     presentationController?.delegate = self
 
+    webView.allowsLinkPreview = false
     webView.navigationDelegate = self
     webView.load(URLRequest(url: checkoutUrl))
   }


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T06:17:23Z" title="Tuesday, July 7th 2020, 4:17:23 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T06:30:27Z" title="Tuesday, July 7th 2020, 4:30:27 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="adamjcampbell" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/adamjcampbell) **Authored by [adamjcampbell](https://github.com/adamjcampbell)**
_<time datetime="2020-06-24T04:53:41Z" title="Wednesday, June 24th 2020, 2:53:41 pm +10:00">Jun 24, 2020</time>_
_Merged <time datetime="2020-06-24T04:59:34Z" title="Wednesday, June 24th 2020, 2:59:34 pm +10:00">Jun 24, 2020</time>_
---

<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/ittybittyapps/afterpay-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Turns off `allowsLinkPreview` in the web view

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

Having this set to its default of `true` allowed for some undesirable behaviour depicted below:
![2020-06-24 14 51 59](https://user-images.githubusercontent.com/5327203/85502314-6655c480-b62a-11ea-82fd-4d4ba7e21480.gif)
