### PR TITLE
Add a navigation bar to the modally presented Afterpay webview

### DIFF
--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -34,14 +34,20 @@ public enum Afterpay {
     cancelHandler: (() -> Void)? = nil,
     successHandler: @escaping (_ token: String) -> Void
   ) {
-    let checkoutViewController = WebViewController(
+    let webViewController = WebViewController(
       checkoutUrl: checkoutUrl,
       cancelHandler: cancelHandler ?? {},
       successHandler: successHandler
     )
 
+    let navigationController = UINavigationController(rootViewController: webViewController)
+
+    if #available(iOS 13.0, *) {
+      navigationController.isModalInPresentation = true
+    }
+
     viewController.present(
-      checkoutViewController,
+      navigationController,
       animated: animated,
       completion: presentationCompletion
     )

--- a/Sources/Afterpay/WebViewController.swift
+++ b/Sources/Afterpay/WebViewController.swift
@@ -9,12 +9,7 @@
 import UIKit
 import WebKit
 
-// swiftlint:disable:next colon
-final class WebViewController:
-  UIViewController,
-  UIAdaptivePresentationControllerDelegate,
-  WKNavigationDelegate
-{ // swiftlint:disable:this opening_brace
+final class WebViewController: UIViewController, WKNavigationDelegate {
 
   private let checkoutUrl: URL
   private let cancelHandler: () -> Void
@@ -47,33 +42,28 @@ final class WebViewController:
       overrideUserInterfaceStyle = .light
     }
 
-    presentationController?.delegate = self
+    title = "Afterpay"
+
+    let closeItem: UIBarButtonItem
+    let closeAction = #selector(didTapClose)
+
+    if #available(iOS 13.0, *) {
+      closeItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: closeAction)
+    } else {
+      closeItem = UIBarButtonItem(title: "Close", style: .plain, target: self, action: closeAction)
+    }
+
+    navigationItem.rightBarButtonItem = closeItem
 
     webView.allowsLinkPreview = false
     webView.navigationDelegate = self
     webView.load(URLRequest(url: checkoutUrl))
   }
 
-  // MARK: UIAdaptivePresentationControllerDelegate
+  // MARK: Actions
 
-  func presentationControllerShouldDismiss(
-    _ presentationController: UIPresentationController
-  ) -> Bool {
-    let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-    let dismiss: (UIAlertAction) -> Void = { _ in
-      self.dismiss(animated: true, completion: self.cancelHandler)
-    }
-
-    let actions = [
-      UIAlertAction(title: "Discard Payment", style: .destructive, handler: dismiss),
-      UIAlertAction(title: "Cancel", style: .cancel, handler: nil),
-    ]
-
-    actions.forEach(actionSheet.addAction)
-
-    present(actionSheet, animated: true, completion: nil)
-
-    return false
+  @objc private func didTapClose() {
+    dismiss(animated: true, completion: self.cancelHandler)
   }
 
   // MARK: WKNavigationDelegate


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T06:17:28Z" title="Tuesday, July 7th 2020, 4:17:28 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T06:30:31Z" title="Tuesday, July 7th 2020, 4:30:31 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="adamjcampbell" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/adamjcampbell) **Authored by [adamjcampbell](https://github.com/adamjcampbell)**
_<time datetime="2020-06-24T06:28:45Z" title="Wednesday, June 24th 2020, 4:28:45 pm +10:00">Jun 24, 2020</time>_
_Closed <time datetime="2020-06-30T00:08:42Z" title="Tuesday, June 30th 2020, 10:08:42 am +10:00">Jun 30, 2020</time>_
---

<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/ittybittyapps/afterpay-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adds a navigation bar with a close button to allow dismissal of the afterpay web view

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

This is necessitated by the need to allow users to exit the modal flow when the webview doesn't allow that option. E.g. a bugged loading state or an error state.

This isn't ideal but might be required (still brainstorming ideas):

| iOS 12 | iOS 13 |
| --- | --- |
| ![Simulator Screen Shot - iPhone 6 12 4 - 2020-06-24 at 14 33 36](https://user-images.githubusercontent.com/5327203/85508512-935ca400-b637-11ea-919b-e2cb2b499ae3.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-06-24 at 14 32 06](https://user-images.githubusercontent.com/5327203/85508481-8049d400-b637-11ea-9241-7173aec2e862.png) |
