### PR TITLE
Add documentation for manually integrating the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Afterpay iOS SDK
-![Build and Test](https://github.com/ittybittyapps/afterpay-ios/workflows/Build%20and%20Test/badge.svg?branch=master&event=push) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+
+![Build and Test][badge-ci] [![Carthage compatible][badge-carthage]][carthage]
 
 The Afterpay iOS SDK provides conveniences to make your Afterpay integration experience as smooth and straightforward as possible. We're working on crafting a great framework for developers with easy drop in components to make payments easy for your customers.
 
@@ -160,6 +161,9 @@ Contributions are welcome! Please read our [contributing guidelines][contributin
 This project is licensed under the terms of the Apache 2.0 license. See the [LICENSE][license] file for more information.
 
 <!-- Links: -->
+[badge-ci]: https://github.com/ittybittyapps/afterpay-ios/workflows/Build%20and%20Test/badge.svg?branch=master&event=push
+[badge-carthage]: https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat
+[carthage]: https://github.com/Carthage/Carthage
 [contributing]: CONTRIBUTING.md
 [example]: Example
 [git-submodule]: https://git-scm.com/docs/git-submodule


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T06:17:56Z" title="Tuesday, July 7th 2020, 4:17:56 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T06:30:54Z" title="Tuesday, July 7th 2020, 4:30:54 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-07-03T02:33:11Z" title="Friday, July 3rd 2020, 12:33:11 pm +10:00">Jul 3, 2020</time>_
_Merged <time datetime="2020-07-06T04:01:43Z" title="Monday, July 6th 2020, 2:01:43 pm +10:00">Jul 6, 2020</time>_
---

## Summary of Changes

- Add instructions for manually integrating the Afterpay SDK.
- Cleanup some newlines between markdown headings.

## Items of Note

I was considering adding an image to visualise the process of adding the framework to a project. What do you think about including this in the repo?

![Manual Integration Instructions](https://user-images.githubusercontent.com/5798516/86425736-478db700-bd29-11ea-9bb5-ee66378877e6.png)