### PR TITLE
Use logic controller to present success and reset quantities

### DIFF
--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -70,9 +70,7 @@ final class PurchaseFlowController: UIViewController {
           Afterpay.presentCheckoutModally(over: navigationController, loading: url) { result in
             switch result {
             case .success(let token):
-              let messageViewController = MessageViewController(message: "Success with: \(token)")
-              let viewControllers = [self.productsViewController, messageViewController]
-              navigationController.setViewControllers(viewControllers, animated: true)
+              self.logicController.success(with: token)
 
             case .cancelled:
               break
@@ -84,6 +82,11 @@ final class PurchaseFlowController: UIViewController {
         let alert = AlertFactory.alert(for: error)
 
         action = { navigationController.present(alert, animated: true, completion: nil) }
+
+      case .showSuccessWithMessage(let message):
+        let messageViewController = MessageViewController(message: message)
+        let viewControllers = [self.productsViewController, messageViewController]
+        action = { navigationController.setViewControllers(viewControllers, animated: true) }
       }
 
       DispatchQueue.main.async(execute: action)

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -20,6 +20,7 @@ final class PurchaseLogicController {
     case showCart(CartDisplay)
     case showAfterpayCheckout(URL)
     case showAlertForCheckoutURLError(Error)
+    case showSuccessWithMessage(String)
   }
 
   var commandHandler: (Command) -> Void = { _ in } {
@@ -74,6 +75,12 @@ final class PurchaseLogicController {
         commandHandler(.showAlertForCheckoutURLError(error))
       }
     }
+  }
+
+  func success(with token: String) {
+    quantities = [:]
+    commandHandler(.updateProducts(productDisplayModels))
+    commandHandler(.showSuccessWithMessage("Success with: \(token)"))
   }
 
 }


### PR DESCRIPTION
> [<img alt="adamjcampbell" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/adamjcampbell) **Authored by [adamjcampbell](https://github.com/adamjcampbell)**
_<time datetime="2020-07-09T04:39:03Z" title="Thursday, July 9th 2020, 2:39:03 pm +10:00">Jul 9, 2020</time>_
_Merged <time datetime="2020-07-09T04:43:57Z" title="Thursday, July 9th 2020, 2:43:57 pm +10:00">Jul 9, 2020</time>_
---

<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/ittybittyapps/afterpay-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adds `showSuccessWithMessage` command
- Informs logic controller of success
- Resets quantities after a successful purchase

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

Builds on top of #56 