### PR TITLE
Call into objective-c code when the objective c language setting is set

### DIFF
--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -49,13 +49,13 @@ final class PurchaseFlowController: UIViewController {
       let navigationController = self.ownedNavigationController
       let action: () -> Void
 
-      switch command {
-      case .updateProducts(let products):
+      switch (command, Settings.language) {
+      case (.updateProducts(let products), _):
         action = {
           self.productsViewController.update(products: products)
         }
 
-      case .showCart(let cart):
+      case (.showCart(let cart), _):
         let cartViewController = CartViewController(cart: cart) { event in
           switch event {
           case .didTapPay:
@@ -65,7 +65,7 @@ final class PurchaseFlowController: UIViewController {
 
         action = { navigationController.pushViewController(cartViewController, animated: true) }
 
-      case .showAfterpayCheckout(let url):
+      case (.showAfterpayCheckout(let url), .swift):
         action = {
           Afterpay.presentCheckoutModally(over: navigationController, loading: url) { result in
             switch result {
@@ -78,12 +78,19 @@ final class PurchaseFlowController: UIViewController {
           }
         }
 
-      case .showAlertForCheckoutURLError(let error):
+      case (.showAfterpayCheckout(let url), .objectiveC):
+        action = {
+          Objc.presentCheckoutModally(over: navigationController, loading: url) { token in
+            self.logicController.success(with: token)
+          }
+        }
+
+      case (.showAlertForCheckoutURLError(let error), _):
         let alert = AlertFactory.alert(for: error)
 
         action = { navigationController.present(alert, animated: true, completion: nil) }
 
-      case .showSuccessWithMessage(let message):
+      case (.showSuccessWithMessage(let message), _):
         let messageViewController = MessageViewController(message: message)
         let viewControllers = [self.productsViewController, messageViewController]
         action = { navigationController.setViewControllers(viewControllers, animated: true) }


### PR DESCRIPTION
> [<img alt="adamjcampbell" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/adamjcampbell) **Authored by [adamjcampbell](https://github.com/adamjcampbell)**
_<time datetime="2020-07-09T08:06:42Z" title="Thursday, July 9th 2020, 6:06:42 pm +10:00">Jul 9, 2020</time>_
_Merged <time datetime="2020-07-10T06:11:52Z" title="Friday, July 10th 2020, 4:11:52 pm +10:00">Jul 10, 2020</time>_
---

<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/ittybittyapps/afterpay-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adds language to the command switch
- Calls objective-c from swift when objective c is set and vice versa when the other is set

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->
@Rypac added a small PR to show you how consuming your work might look, pretty simple with enums.
I first tried using: `where Settings.language == .swift` but appending that to the case means it can't infer that you have covered all cases unless it's _inside_ the switch
