### PR TITLE
Migrate GitHub repository URLs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ appropriately.
 
 Bug fixes and new features should include tests and documentation.
 
-Contributors guide: https://github.com/ittybittyapps/afterpay-ios/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/AfterpayTouch/afterpay-ios/blob/master/CONTRIBUTING.md
 -->
 
 ## Summary of Changes

--- a/Afterpay.podspec
+++ b/Afterpay.podspec
@@ -13,11 +13,11 @@ Pod::Spec.new do |spec|
   spec.description  = <<-DESC
     The Afterpay iOS SDK provides drop in UI Components for a smooth Afterpay integration.
   DESC
-  spec.homepage     = "https://github.com/ittybittyapps/afterpay-ios"
+  spec.homepage     = "https://github.com/AfterpayTouch/afterpay-ios"
   spec.license      = "Apache License, Version 2.0"
   spec.author       = "Afterpay"
   spec.platform     = :ios, "12.0"
-  spec.source       = { :git => "https://github.com/ittybittyapps/afterpay-ios.git", :tag => "#{spec.version}" }
+  spec.source       = { :git => "https://github.com/AfterpayTouch/afterpay-ios.git", :tag => "#{spec.version}" }
   spec.source_files = "Sources"
   spec.framework    = "UIKit"
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,13 +67,13 @@ All contributions to this project are also under this license as per [GitHub's T
 [code-of-conduct]: CODE_OF_CONDUCT.md
 [code-owners]: .github/CODEOWNERS
 [commit-messages]: https://chris.beams.io/posts/git-commit/
-[fork-repo]: https://github.com/ittybittyapps/afterpay-ios/fork
+[fork-repo]: https://github.com/AfterpayTouch/afterpay-ios/fork
 [fork-docs]: https://help.github.com/articles/working-with-forks/
 [github-terms-contribution]: https://help.github.com/en/github/site-policy/github-terms-of-service#6-contributions-under-repository-license
-[issues]: https://github.com/ittybittyapps/afterpay-ios/issues
+[issues]: https://github.com/AfterpayTouch/afterpay-ios/issues
 [license]: LICENSE
 [mint]: https://github.com/yonaskolb/Mint
-[new-issue]: https://github.com/ittybittyapps/afterpay-ios/issues/new/choose
+[new-issue]: https://github.com/AfterpayTouch/afterpay-ios/issues/new/choose
 [pr-template]: .github/PULL_REQUEST_TEMPLATE.md
 [pr-docs]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review
 [readme]: README.md

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Download the [latest release][latest-release] from GitHub and unzip into an `Aft
 Add the Afterpay SDK as a [git submodule][git-submodule] by navigating to the root of your working directory and running the following commands:
 
 ```
-git submodule add https://github.com/ittybittyapps/afterpay-ios.git Afterpay
+git submodule add https://github.com/AfterpayTouch/afterpay-ios.git Afterpay
 cd Afterpay
 git checkout 0.0.1
 ```
@@ -179,14 +179,14 @@ This project is licensed under the terms of the Apache 2.0 license. See the [LIC
 
 <!-- Links: -->
 [afterpay-workspace]: Afterpay.xcworkspace
-[badge-ci]: https://github.com/ittybittyapps/afterpay-ios/workflows/Build%20and%20Test/badge.svg?branch=master&event=push
+[badge-ci]: https://github.com/AfterpayTouch/afterpay-ios/workflows/Build%20and%20Test/badge.svg?branch=master&event=push
 [badge-carthage]: https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat
 [bootstrap]: Scripts/bootstrap
 [carthage]: https://github.com/Carthage/Carthage
 [contributing]: CONTRIBUTING.md
 [example]: Example
 [git-submodule]: https://git-scm.com/docs/git-submodule
-[latest-release]: https://github.com/ittybittyapps/afterpay-ios/releases/latest
+[latest-release]: https://github.com/AfterpayTouch/afterpay-ios/releases/latest
 [license]: LICENSE
 [mint]: https://github.com/yonaskolb/Mint
 [mint-directory]: Tools/mint


### PR DESCRIPTION
> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-07-09T23:57:43Z" title="Friday, July 10th 2020, 9:57:43 am +10:00">Jul 10, 2020</time>_
_Merged <time datetime="2020-07-10T00:38:31Z" title="Friday, July 10th 2020, 10:38:31 am +10:00">Jul 10, 2020</time>_
---

## Summary of Changes

- Replace use of IBA GitHub URLs with new Afterpay repository.