### PR TITLE
Provide a cancellation reason when the checkout has been cancelled

### DIFF
--- a/Sources/Afterpay/CheckoutResult.swift
+++ b/Sources/Afterpay/CheckoutResult.swift
@@ -10,5 +10,10 @@ import Foundation
 
 @frozen public enum CheckoutResult {
   case success(token: String)
-  case cancelled(error: Error?)
+  case cancelled(reason: CancellationReason)
+
+  public enum CancellationReason {
+    case userInitiated
+    case networkError(Error)
+  }
 }

--- a/Sources/Afterpay/WebViewController.swift
+++ b/Sources/Afterpay/WebViewController.swift
@@ -78,7 +78,7 @@ final class WebViewController:
     )
 
     let cancelPayment: (UIAlertAction) -> Void = { _ in
-      self.dismiss(animated: true) { self.completion(.cancelled(error: nil)) }
+      self.dismiss(animated: true) { self.completion(.cancelled(reason: .userInitiated)) }
     }
 
     let actions = [
@@ -137,7 +137,7 @@ final class WebViewController:
 
     case (false, .cancelled):
       decisionHandler(.cancel)
-      dismiss(animated: true) { self.completion(.cancelled(error: nil)) }
+      dismiss(animated: true) { self.completion(.cancelled(reason: .userInitiated)) }
 
     case (false, nil):
       decisionHandler(.allow)
@@ -159,7 +159,7 @@ final class WebViewController:
     }
 
     let cancelHandler: (UIAlertAction) -> Void = { _ in
-      self.dismiss(animated: true) { self.completion(.cancelled(error: error)) }
+      self.dismiss(animated: true) { self.completion(.cancelled(reason: .networkError(error))) }
     }
 
     alert.addAction(UIAlertAction(title: "Retry", style: .default, handler: retryHandler))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adds `CancellationReason` enum and matching objective-c wrappers
-
-

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

If I were to consume this in the example app what are your thoughts on how I should show it @Rypac ? We don't have a toast so I guess I could show an alert?
