### PR TITLE
Harden Swiftlint build phase script to avoid build failures

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/Scripts/swiftlint-sdk\n";
+			shellScript = "\"$SRCROOT\"/Scripts/swiftlint-sdk\n";
 		};
 		66B57E61248F5D300020C642 /* Ensure No Project Build Settings */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Scripts/swiftlint-sdk
+++ b/Scripts/swiftlint-sdk
@@ -5,9 +5,13 @@ set -euo pipefail
 # the default SDK for the platform not the one set by the build script
 unset SDKROOT
 
-./Tools/mint/mint run swiftlint \
-  --quiet \
-  -- \
-  Package.swift \
-  Sources \
-  AfterpayTests
+: "${CARTHAGE:=NO}"
+
+if [ "$CARTHAGE" != "YES" ]; then
+  ./Tools/mint/mint run swiftlint \
+    --quiet \
+    -- \
+    Package.swift \
+    Sources \
+    AfterpayTests
+fi


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Quotes `$SRCROOT` to avoid path issues when running scripts
- Opts not to run swiftlint when building for Carthage

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

This was discovered when trying to build with Carthage in a `Test Projects` directory and opts not to not run swiftlint when in a Carthage context.