### PR TITLE
Add an authentication challenge handler to the SDK

### DIFF
--- a/Afterpay.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Afterpay.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "TrustKit",
+        "repositoryURL": "https://github.com/datatheorem/TrustKit",
+        "state": {
+          "branch": null,
+          "revision": "714fd3fcdcada5b107d91bf6caaaefb00f792730",
+          "version": "1.6.5"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Configurations/Afterpay-Shared.xcconfig
+++ b/Configurations/Afterpay-Shared.xcconfig
@@ -178,4 +178,4 @@ TARGETED_DEVICE_FAMILY = 1,2
 // This setting defines the user-visible version of the project. The value corresponds to
 // the `CFBundleShortVersionString` key in your app's Info.plist.
 
-MARKETING_VERSION = 1.0.2
+MARKETING_VERSION = 1.1.0

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		665E6A0B24935624009E3BA1 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665E6A0A24935624009E3BA1 /* Extensions.swift */; };
 		6662628A2496F5EB0094FC26 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666262892496F5EB0094FC26 /* Networking.swift */; };
 		667F833924C815DC0077DC5F /* TrustKit in Frameworks */ = {isa = PBXBuildFile; productRef = 667F833824C815DC0077DC5F /* TrustKit */; };
+		667F833B24C819120077DC5F /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667F833A24C819120077DC5F /* Dependencies.swift */; };
 		6686CC4924A08E450043EF94 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6686CC4824A08E450043EF94 /* Settings.swift */; };
 		668F162224877F950040345C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668F162124877F950040345C /* AppDelegate.swift */; };
 		668F162424877F950040345C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668F162324877F950040345C /* SceneDelegate.swift */; };
@@ -71,6 +72,7 @@
 		665E6A0A24935624009E3BA1 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		666262892496F5EB0094FC26 /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
 		66690EE224BE81F700600C99 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
+		667F833A24C819120077DC5F /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
 		6686CC4824A08E450043EF94 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		668F161E24877F950040345C /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		668F162124877F950040345C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				664722A624A5D9B00079B1FB /* AlertFactory.swift */,
 				6650F41D24BC0F1B00B16A57 /* Buttons.swift */,
 				6650F41B24BC03DC00B16A57 /* Colors.swift */,
+				667F833A24C819120077DC5F /* Dependencies.swift */,
 				665E6A0A24935624009E3BA1 /* Extensions.swift */,
 				663A228D249B030D0027C296 /* MessageViewController.swift */,
 				666262892496F5EB0094FC26 /* Networking.swift */,
@@ -351,6 +354,7 @@
 				66BD11B424ADB7EB00039DA6 /* TitleSubtitleCell.swift in Sources */,
 				665311C324AC23D10088A063 /* ProductCell.swift in Sources */,
 				66BD11B024ADB0F300039DA6 /* CartDisplay.swift in Sources */,
+				667F833B24C819120077DC5F /* Dependencies.swift in Sources */,
 				6650F41E24BC0F1B00B16A57 /* Buttons.swift in Sources */,
 				66E6FDA624AC377D00ED81E8 /* Product.swift in Sources */,
 				6686CC4924A08E450043EF94 /* Settings.swift in Sources */,

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,6 +19,7 @@
 		665311C324AC23D10088A063 /* ProductCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665311C224AC23D10088A063 /* ProductCell.swift */; };
 		665E6A0B24935624009E3BA1 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665E6A0A24935624009E3BA1 /* Extensions.swift */; };
 		6662628A2496F5EB0094FC26 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666262892496F5EB0094FC26 /* Networking.swift */; };
+		667F833924C815DC0077DC5F /* TrustKit in Frameworks */ = {isa = PBXBuildFile; productRef = 667F833824C815DC0077DC5F /* TrustKit */; };
 		6686CC4924A08E450043EF94 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6686CC4824A08E450043EF94 /* Settings.swift */; };
 		668F162224877F950040345C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668F162124877F950040345C /* AppDelegate.swift */; };
 		668F162424877F950040345C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668F162324877F950040345C /* SceneDelegate.swift */; };
@@ -97,6 +98,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				667F833924C815DC0077DC5F /* TrustKit in Frameworks */,
 				66F9767824999F5C001D38FA /* Afterpay.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -246,6 +248,7 @@
 			);
 			name = Example;
 			packageProductDependencies = (
+				667F833824C815DC0077DC5F /* TrustKit */,
 			);
 			productName = Example;
 			productReference = 668F161E24877F950040345C /* Example.app */;
@@ -276,6 +279,9 @@
 				Base,
 			);
 			mainGroup = 668F161524877F950040345C;
+			packageReferences = (
+				667F833724C815DC0077DC5F /* XCRemoteSwiftPackageReference "TrustKit" */,
+			);
 			productRefGroup = 668F161F24877F950040345C /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -558,6 +564,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		667F833724C815DC0077DC5F /* XCRemoteSwiftPackageReference "TrustKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/datatheorem/TrustKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.6.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		667F833824C815DC0077DC5F /* TrustKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 667F833724C815DC0077DC5F /* XCRemoteSwiftPackageReference "TrustKit" */;
+			productName = TrustKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 668F161624877F950040345C /* Project object */;
 }

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -17,6 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, WindowHolder {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    initializeDependencies()
+
     if #available(iOS 13.0, *) {
       // Window installation handled by SceneDelegate
     } else {

--- a/Example/Example/AppFlowController.swift
+++ b/Example/Example/AppFlowController.swift
@@ -8,16 +8,16 @@
 
 import Foundation
 import SwiftUI
-import TrustKit
 import UIKit
 
 final class AppFlowController: UIViewController {
 
-  private let dependencies = Dependencies()
   private let ownedTabBarController = UITabBarController()
 
   init() {
     super.init(nibName: nil, bundle: nil)
+
+    initializeDependencies()
 
     let purchaseLogicController = PurchaseLogicController(
       checkoutURLProvider: checkout,

--- a/Example/Example/AppFlowController.swift
+++ b/Example/Example/AppFlowController.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import SwiftUI
 import UIKit
 
 final class AppFlowController: UIViewController {
@@ -16,8 +15,6 @@ final class AppFlowController: UIViewController {
 
   init() {
     super.init(nibName: nil, bundle: nil)
-
-    initializeDependencies()
 
     let purchaseLogicController = PurchaseLogicController(
       checkoutURLProvider: checkout,

--- a/Example/Example/AppFlowController.swift
+++ b/Example/Example/AppFlowController.swift
@@ -8,10 +8,12 @@
 
 import Foundation
 import SwiftUI
+import TrustKit
 import UIKit
 
 final class AppFlowController: UIViewController {
 
+  private let dependencies = Dependencies()
   private let ownedTabBarController = UITabBarController()
 
   init() {

--- a/Example/Example/Shared/Dependencies.swift
+++ b/Example/Example/Shared/Dependencies.swift
@@ -6,23 +6,35 @@
 //  Copyright © 2020 Afterpay. All rights reserved.
 //
 
+import Afterpay
+import CommonCrypto
 import Foundation
 import TrustKit
 
 func initializeDependencies() {
+  // In a real world scenario this would be a real backup hash but for demonstration purposes
+  // it is an empty hash to satisfy TrustKit's requirements
+  let backupHash = Data(count: Int(CC_SHA256_DIGEST_LENGTH)).base64EncodedString()
+
   let configuration: [String: Any] = [
     kTSKSwizzleNetworkDelegates: false,
     kTSKPinnedDomains: [
       "portal.afterpay.com": [
         kTSKExpirationDate: "2022-06-25",
-        kTSKPublicKeyHashes: ["nQ1Tu17lpJ/Hsr3545eCkig+X9ZPcxRQoe5WMSyyqJI="],
+        kTSKPublicKeyHashes: ["nQ1Tu17lpJ/Hsr3545eCkig+X9ZPcxRQoe5WMSyyqJI=", backupHash],
       ],
       "portal.sandbox.afterpay.com": [
         kTSKExpirationDate: "2021-07-05",
-        kTSKPublicKeyHashes: ["15mVY9KpcF6J/UzKCS2AfUjUWPVsIvxi9PW0XuFnvH4="],
+        kTSKPublicKeyHashes: ["15mVY9KpcF6J/UzKCS2AfUjUWPVsIvxi9PW0XuFnvH4=", backupHash],
       ],
     ],
   ]
 
   TrustKit.initSharedInstance(withConfiguration: configuration)
+
+  // Pin Afterpay's payment portal certificates using TrustKit
+  Afterpay.setAuthenticationChallengeHandler { challenge, completionHandler -> Bool in
+    let validator = TrustKit.sharedInstance().pinningValidator
+    return validator.handle(challenge, completionHandler: completionHandler)
+  }
 }

--- a/Example/Example/Shared/Dependencies.swift
+++ b/Example/Example/Shared/Dependencies.swift
@@ -1,0 +1,38 @@
+//
+//  Dependencies.swift
+//  Example
+//
+//  Created by Adam Campbell on 22/7/20.
+//  Copyright © 2020 Afterpay. All rights reserved.
+//
+
+import Foundation
+import TrustKit
+
+struct Dependencies {
+
+  var pinningValidator: TSKPinningValidator { TrustKit.sharedInstance().pinningValidator }
+
+  init() {
+    let afterpay: [String: Any] = [
+      kTSKExpirationDate: "2022-06-25",
+      kTSKPublicKeyHashes: ["nQ1Tu17lpJ/Hsr3545eCkig+X9ZPcxRQoe5WMSyyqJI="],
+    ]
+
+    let sandbox: [String: Any] = [
+      kTSKExpirationDate: "2021-07-05",
+      kTSKPublicKeyHashes: ["15mVY9KpcF6J/UzKCS2AfUjUWPVsIvxi9PW0XuFnvH4="],
+    ]
+
+    let configuration: [String: Any] = [
+      kTSKSwizzleNetworkDelegates: false,
+      kTSKPinnedDomains: [
+        "portal.afterpay.com": afterpay,
+        "portal.sandbox.afterpay.com": sandbox,
+      ],
+    ]
+
+    TrustKit.initSharedInstance(withConfiguration: configuration)
+  }
+
+}

--- a/Example/Example/Shared/Dependencies.swift
+++ b/Example/Example/Shared/Dependencies.swift
@@ -9,30 +9,20 @@
 import Foundation
 import TrustKit
 
-struct Dependencies {
-
-  var pinningValidator: TSKPinningValidator { TrustKit.sharedInstance().pinningValidator }
-
-  init() {
-    let afterpay: [String: Any] = [
-      kTSKExpirationDate: "2022-06-25",
-      kTSKPublicKeyHashes: ["nQ1Tu17lpJ/Hsr3545eCkig+X9ZPcxRQoe5WMSyyqJI="],
-    ]
-
-    let sandbox: [String: Any] = [
-      kTSKExpirationDate: "2021-07-05",
-      kTSKPublicKeyHashes: ["15mVY9KpcF6J/UzKCS2AfUjUWPVsIvxi9PW0XuFnvH4="],
-    ]
-
-    let configuration: [String: Any] = [
-      kTSKSwizzleNetworkDelegates: false,
-      kTSKPinnedDomains: [
-        "portal.afterpay.com": afterpay,
-        "portal.sandbox.afterpay.com": sandbox,
+func initializeDependencies() {
+  let configuration: [String: Any] = [
+    kTSKSwizzleNetworkDelegates: false,
+    kTSKPinnedDomains: [
+      "portal.afterpay.com": [
+        kTSKExpirationDate: "2022-06-25",
+        kTSKPublicKeyHashes: ["nQ1Tu17lpJ/Hsr3545eCkig+X9ZPcxRQoe5WMSyyqJI="],
       ],
-    ]
+      "portal.sandbox.afterpay.com": [
+        kTSKExpirationDate: "2021-07-05",
+        kTSKPublicKeyHashes: ["15mVY9KpcF6J/UzKCS2AfUjUWPVsIvxi9PW0XuFnvH4="],
+      ],
+    ],
+  ]
 
-    TrustKit.initSharedInstance(withConfiguration: configuration)
-  }
-
+  TrustKit.initSharedInstance(withConfiguration: configuration)
 }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The Afterpay iOS SDK provides conveniences to make your Afterpay integration exp
   - [Web Checkout](#web-checkout)
     - [Note](#note)
   - [Security](#security)
+    - [Swift](#swift)
+    - [Objective-C](#objective-c)
 - [Getting Started](#getting-started)
   - [Presenting Web Checkout](#presenting-web-checkout)
     - [Swift (UIKit)](#swift-uikit)
@@ -133,11 +135,29 @@ dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
 
 For added security, a method to hook into the SDKs WKWebView Authentication Challenge Handler is provided. With this you can implement things like SSL Pinning to ensure you can trust your end to end connections. An example of this has been provided in the [example project][example] and in the snippet below using [TrustKit][trust-kit]. In this handler you must return whether or not you have handled the challenge yourself (have called the completionHandler) by returning `true`, or if you wish to fall back to the default handling by returning `false`.
 
+### Swift
+
 ```swift
 Afterpay.setAuthenticationChallengeHandler { challenge, completionHandler -> Bool in
  let validator = TrustKit.sharedInstance().pinningValidator
  return validator.handle(challenge, completionHandler: completionHandler)
 }
+```
+
+### Objective-C
+
+```objc
+typedef void (^ CompletionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *);
+
+BOOL (^challengeHandler)(NSURLAuthenticationChallenge *, CompletionHandler) = ^BOOL(
+ NSURLAuthenticationChallenge *challenge,
+ CompletionHandler completionHandler
+) {
+ TSKPinningValidator *pinningValidator = [[TrustKit sharedInstance] pinningValidator];
+ return [pinningValidator handleChallenge:challenge completionHandler:completionHandler];
+};
+
+[APAfterpay setAuthenticationChallengeHandler:challengeHandler];
 ```
 
 # Getting Started

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Add the Afterpay SDK as a [git submodule][git-submodule] by navigating to the ro
 ```
 git submodule add https://github.com/afterpay/sdk-ios.git Afterpay
 cd Afterpay
-git checkout 1.0.2
+git checkout 1.1.0
 ```
 
 #### Project / Workspace Integration

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The Afterpay iOS SDK provides conveniences to make your Afterpay integration exp
 - [Features](#features)
   - [Web Checkout](#web-checkout)
     - [Note](#note)
+  - [Security](#security)
 - [Getting Started](#getting-started)
   - [Presenting Web Checkout](#presenting-web-checkout)
     - [Swift (UIKit)](#swift-uikit)
@@ -128,6 +129,17 @@ dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
 }
 ```
 
+## Security
+
+For added security, a method to hook into the SDKs WKWebView Authentication Challenge Handler is provided. With this you can implement things like SSL Pinning to ensure you can trust your end to end connections. An example of this has been provided in the [example project][example] and in the snippet below using [TrustKit][trust-kit]. In this handler you must return whether or not you have handled the challenge yourself (have called the completionHandler) by returning `true`, or if you wish to fall back to the default handling by returning `false`.
+
+```swift
+Afterpay.setAuthenticationChallengeHandler { challenge, completionHandler -> Bool in
+ let validator = TrustKit.sharedInstance().pinningValidator
+ return validator.handle(challenge, completionHandler: completionHandler)
+}
+```
+
 # Getting Started
 
 We provide options for integrating the SDK in Swift and Objective-C.
@@ -151,7 +163,6 @@ final class CheckoutViewController: UIViewController {
         // Handle successful Afterpay checkout
       case .cancelled(let reason):
         // Handle checkout cancellation
-        // The SDK provides a few different reasons for cancellation that you can switch on as needed
       }
     }
   }
@@ -201,7 +212,7 @@ struct MyView: View {
 
   var body: some View {
     SomeView()
-      .afterpayCheckout(url: $checkoutURL, completion: checkoutResultHandler) { result in
+      .afterpayCheckout(url: $checkoutURL) { result in
         switch result {
         case .success(let token):
           // Handle successful Afterpay checkout
@@ -262,3 +273,4 @@ This project is licensed under the terms of the Apache 2.0 license. See the [LIC
 [mint]: https://github.com/yonaskolb/Mint
 [mint-directory]: Tools/mint
 [spm]: https://github.com/apple/swift-package-manager
+[trust-kit]: https://github.com/datatheorem/TrustKit

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -40,3 +40,14 @@ public func presentCheckoutModally(
 
   viewController.present(viewControllerToPresent, animated: animated, completion: nil)
 }
+
+public typealias AuthenticationChallengeHandler = (
+  _ challenge: URLAuthenticationChallenge,
+  _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+) -> Bool
+
+var authenticationChallengeHandler: AuthenticationChallengeHandler = { _, _ in false }
+
+public func setAuthenticationChallengeHandler(_ handler: @escaping AuthenticationChallengeHandler) {
+  authenticationChallengeHandler = handler
+}

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -41,6 +41,14 @@ public func presentCheckoutModally(
   viewController.present(viewControllerToPresent, animated: animated, completion: nil)
 }
 
+/// A handler that is passed a `challenge` a `completionHandler`. If the challenge has been
+/// handled (by calling the completionHandler) `true` should be returned, `false` otherwise.
+/// - Parameters:
+///   - challenge: The authentication challenge.
+///   - completionHandler: A block to invoke to respond to the challenge. The disposition parameter
+///   must be one of the constants of the enumerated type URLSession.AuthChallengeDisposition. When
+///   disposition is URLSession.AuthChallengeDisposition.useCredential, the credential parameter
+///   specifies the credential to use, or nil to continue without a credential.
 public typealias AuthenticationChallengeHandler = (
   _ challenge: URLAuthenticationChallenge,
   _ completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
@@ -48,6 +56,10 @@ public typealias AuthenticationChallengeHandler = (
 
 var authenticationChallengeHandler: AuthenticationChallengeHandler = { _, _ in false }
 
+/// Set the authentication challenge handler used by the Afterpay SDK to respond to authentication
+/// challenges during the checkout process.
+/// - Parameter handler: A handler that should return whether or not the challenge has been handled.
+/// `true` if the passed completionHandler has been called, `false` otherwise.
 public func setAuthenticationChallengeHandler(_ handler: @escaping AuthenticationChallengeHandler) {
   authenticationChallengeHandler = handler
 }

--- a/Sources/Afterpay/ObjcWrapper.swift
+++ b/Sources/Afterpay/ObjcWrapper.swift
@@ -121,4 +121,11 @@ public final class ObjcWrapper: NSObject {
     )
   }
 
+  @objc
+  public static func setAuthenticationChallengeHandler(
+    _ handler: @escaping AuthenticationChallengeHandler
+  ) {
+    Afterpay.setAuthenticationChallengeHandler(handler)
+  }
+
 }

--- a/Sources/Afterpay/WebViewController.swift
+++ b/Sources/Afterpay/WebViewController.swift
@@ -191,6 +191,18 @@ final class WebViewController:
     present(alert, animated: true, completion: nil)
   }
 
+  func webView(
+    _ webView: WKWebView,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    let handled = authenticationChallengeHandler(challenge, completionHandler)
+
+    if handled == false {
+      completionHandler(.performDefaultHandling, nil)
+    }
+  }
+
   // MARK: Unavailable
 
   @available(*, unavailable)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adds the ability to set an authentication trust handler to the SDK
- Documents the trust handler and adds an objective-c variant
- Pins to the afterpay portals for the afterpay domain in the Example app
- Updates the version to `1.1.0` to reflect the backwards compatible addition of functionality
