### PR TITLE
Adds SwiftSVG as a dependency of the AfterpaySDK

### DIFF
--- a/Afterpay.podspec
+++ b/Afterpay.podspec
@@ -13,4 +13,6 @@ Pod::Spec.new do |spec|
   spec.source_files  = "Sources/Afterpay/"
   spec.swift_version = "5.1"
   spec.framework     = "UIKit"
+
+  spec.dependency "SwiftSVG", "2.3.2"
 end

--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,6 +11,7 @@
 		6635B95F24CAA9F000EBB3A6 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6635B95E24CAA9F000EBB3A6 /* ConfigurationTests.swift */; };
 		665FC57C2488766C00A5A93E /* Afterpay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 668F16072487653A0040345C /* Afterpay.framework */; };
 		666D334C24A48F5C00FCD464 /* ObjcWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666D334B24A48F5C00FCD464 /* ObjcWrapper.swift */; };
+		6670F8AF24D1017B007D41DD /* SwiftSVG in Frameworks */ = {isa = PBXBuildFile; productRef = 6670F8AE24D1017B007D41DD /* SwiftSVG */; };
 		667AD3542497121200BF94E5 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667AD3532497121100BF94E5 /* WebViewController.swift */; };
 		6689536C24C96CB5005090B4 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6689536B24C96CB5005090B4 /* Configuration.swift */; };
 		66D685B224BD3FB900C7287C /* SwiftUIWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D685B124BD3FB900C7287C /* SwiftUIWrapper.swift */; };
@@ -65,6 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6670F8AF24D1017B007D41DD /* SwiftSVG in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,6 +208,9 @@
 			dependencies = (
 			);
 			name = Afterpay;
+			packageProductDependencies = (
+				6670F8AE24D1017B007D41DD /* SwiftSVG */,
+			);
 			productName = Afterpay;
 			productReference = 668F16072487653A0040345C /* Afterpay.framework */;
 			productType = "com.apple.product-type.framework";
@@ -238,6 +243,9 @@
 				Base,
 			);
 			mainGroup = 668F15FD2487653A0040345C;
+			packageReferences = (
+				6670F8AD24D1017B007D41DD /* XCRemoteSwiftPackageReference "SwiftSVG" */,
+			);
 			productRefGroup = 668F16082487653A0040345C /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -410,6 +418,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6670F8AD24D1017B007D41DD /* XCRemoteSwiftPackageReference "SwiftSVG" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mchoe/SwiftSVG";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.3.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6670F8AE24D1017B007D41DD /* SwiftSVG */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6670F8AD24D1017B007D41DD /* XCRemoteSwiftPackageReference "SwiftSVG" */;
+			productName = SwiftSVG;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 668F15FE2487653A0040345C /* Project object */;
 }

--- a/Afterpay.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Afterpay.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "SwiftSVG",
+        "repositoryURL": "https://github.com/mchoe/SwiftSVG",
+        "state": {
+          "branch": null,
+          "revision": "c3a8866a25ace169ee8e5c037670ba14aa59606f",
+          "version": "2.3.2"
+        }
+      },
+      {
         "package": "TrustKit",
         "repositoryURL": "https://github.com/datatheorem/TrustKit",
         "state": {

--- a/Configurations/Afterpay-Shared.xcconfig
+++ b/Configurations/Afterpay-Shared.xcconfig
@@ -5,15 +5,6 @@
 // https://github.com/dempseyatgithub/BuildSettingExtractor
 //
 
-// Build Libraries for Distribution
-// 
-// Ensures that your libraries are built for distribution. For Swift, this enables
-// support for library evolution and generation of a module interface file.
-
-BUILD_LIBRARY_FOR_DISTRIBUTION = YES
-
-
-
 // Enable Modules (C and Objective-C)
 // 
 // Enables the use of modules for system APIs. System headers are imported as semantic

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -108,8 +108,6 @@ final class PurchaseLogicController {
       errorMessageToShow = nil
     case .invalidURL(let url):
       errorMessageToShow = "URL: \(url.absoluteString) is invalid for Afterpay Checkout"
-    @unknown default:
-      errorMessageToShow = "Something went wrong"
     }
 
     if let errorMessage = errorMessageToShow {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftSVG",
+        "repositoryURL": "https://github.com/mchoe/SwiftSVG.git",
+        "state": {
+          "branch": null,
+          "revision": "c3a8866a25ace169ee8e5c037670ba14aa59606f",
+          "version": "2.3.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,11 @@ let package = Package(
   products: [
     .library(name: "Afterpay", targets: ["Afterpay"]),
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/mchoe/SwiftSVG.git", from: "2.3.2"),
+  ],
   targets: [
-    .target(name: "Afterpay", dependencies: []),
+    .target(name: "Afterpay", dependencies: ["SwiftSVG"]),
     .testTarget(name: "AfterpayTests", dependencies: ["Afterpay"], path: "AfterpayTests"),
   ]
 )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Add SwiftSVG to the Afterpay project/workspace
- Add SwiftSVG to `Package.swift`
- Add SwiftSVG to `Afterpay.podspec`

## Items of Note

This will replace the need for Macaw and close #93 
