### PR TITLE
Adds afterpay badge to PriceBreakdownView and makes the text responsive

### DIFF
--- a/Sources/Afterpay/BadgeView.swift
+++ b/Sources/Afterpay/BadgeView.swift
@@ -58,7 +58,7 @@ public final class BadgeView: UIView {
     accessibilityLabel = "after pay"
 
     // SVG Layout
-    svgView = SVGView(svg: style(for: traitCollection).svg)
+    svgView = SVGView(lightSVG: lightStyle.svg, darkSVG: darkStyle.svg)
 
     addSubview(svgView)
 
@@ -68,23 +68,6 @@ public final class BadgeView: UIView {
       svgView.topAnchor.constraint(equalTo: topAnchor),
       svgView.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])
-  }
-
-  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    svgView.svg = style(for: traitCollection).svg
-  }
-
-  private func style(for traitCollection: UITraitCollection) -> Style {
-    switch traitCollection.userInterfaceStyle {
-    case .dark:
-      return darkStyle
-    case .light, .unspecified:
-      fallthrough
-    @unknown default:
-      return lightStyle
-    }
   }
 
 }

--- a/Sources/Afterpay/PriceBreakdownView.swift
+++ b/Sources/Afterpay/PriceBreakdownView.swift
@@ -26,9 +26,6 @@ public final class PriceBreakdownView: UIView {
   }
 
   private func sharedInit() {
-    let attributedString = NSMutableAttributedString(string: "or 4 payments of $40.00 with")
-
-    label.attributedText = attributedString
     label.translatesAutoresizingMaskIntoConstraints = false
     label.numberOfLines = 0
 
@@ -38,6 +35,8 @@ public final class PriceBreakdownView: UIView {
       label.textColor = .black
     }
 
+    updateAttributedText()
+
     addSubview(label)
 
     NSLayoutConstraint.activate([
@@ -46,6 +45,55 @@ public final class PriceBreakdownView: UIView {
       label.trailingAnchor.constraint(equalTo: trailingAnchor),
       label.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])
+  }
+
+  private func updateAttributedText() {
+    let svgView = SVGView(lightSVG: .badgeWhiteOnBlack, darkSVG: .badgeBlackOnWhite)
+    let svg = svgView.svg
+
+    let font: UIFont = .preferredFont(forTextStyle: .body)
+    let fontHeight = font.ascender - font.descender
+
+    let widthFittingFont = fontHeight / svg.aspectRatio
+    let width = widthFittingFont > svg.minimumWidth ? widthFittingFont : svg.minimumWidth
+    let size = CGSize(width: width, height: width * svg.aspectRatio)
+
+    svgView.frame = CGRect(origin: .zero, size: size)
+
+    let renderer = UIGraphicsImageRenderer(size: svgView.bounds.size)
+    let image = renderer.image { rendererContext in
+      svgView.layer.render(in: rendererContext.cgContext)
+    }
+
+    let attributedString = NSMutableAttributedString(
+      string: "or 4 payments of $40.00 with ",
+      attributes: [NSAttributedString.Key.font: font]
+    )
+
+    let badgeAttachment = NSTextAttachment()
+    badgeAttachment.image = image
+    badgeAttachment.bounds = CGRect(origin: .init(x: 0, y: font.descender), size: image.size)
+    let badge = NSAttributedString(attachment: badgeAttachment)
+
+    attributedString.append(badge)
+
+    label.attributedText = attributedString
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+
+    let userInterfaceStyle = traitCollection.userInterfaceStyle
+    let previousUserInterfaceStyle = previousTraitCollection?.userInterfaceStyle
+    let contentSizeCategory = traitCollection.preferredContentSizeCategory
+    let previousContentSizeCategory = previousTraitCollection?.preferredContentSizeCategory
+
+    let userInterfaceStyleChanged = previousUserInterfaceStyle != userInterfaceStyle
+    let contentSizeCategoryChanged = previousContentSizeCategory != contentSizeCategory
+
+    if userInterfaceStyleChanged || contentSizeCategoryChanged {
+      updateAttributedText()
+    }
   }
 
 }

--- a/Sources/Afterpay/SVG.swift
+++ b/Sources/Afterpay/SVG.swift
@@ -15,21 +15,24 @@ import Macaw
 import UIKit
 
 // swiftlint:disable line_length
-struct SVG {
+struct SVG: Equatable {
 
   let size: CGSize
+  let minimumWidth: CGFloat
   private let svgString: String
 
   var aspectRatio: CGFloat { size.height / size.width }
   var node: Node { (try? SVGParser.parse(text: svgString)) ?? Group() }
 
-  init(size: CGSize, svgString: String) {
+  init(size: CGSize, minimumWidth: CGFloat, svgString: String) {
     self.size = size
+    self.minimumWidth = minimumWidth
     self.svgString = svgString
   }
 
   static let badgeWhiteOnBlack: SVG = SVG(
     size: CGSize(width: 1582, height: 551),
+    minimumWidth: 64,
     svgString: """
     <svg width="1582" height="551" viewBox="0 0 1582 551" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M1306.3 550.5H275.2C123.2 550.5 0 427.3 0 275.3C0 123.3 123.2 0.0999756 275.2 0.0999756H1306.3C1458.3 0.0999756 1581.5 123.3 1581.5 275.3C1581.6 427.2 1458.3 550.5 1306.3 550.5Z" fill="#000000"/>
@@ -40,6 +43,7 @@ struct SVG {
 
   static let badgeBlackOnWhite: SVG = SVG(
     size: CGSize(width: 1582, height: 551),
+    minimumWidth: 64,
     svgString: """
     <svg width="1582" height="551" viewBox="0 0 1582 551" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M1306.3 550.5H275.2C123.2 550.5 0 427.3 0 275.3C0 123.3 123.2 0.0999756 275.2 0.0999756H1306.3C1458.3 0.0999756 1581.5 123.3 1581.5 275.3C1581.6 427.2 1458.3 550.5 1306.3 550.5Z" fill="#FFFFFF"/>

--- a/Sources/Afterpay/SVGView.swift
+++ b/Sources/Afterpay/SVGView.swift
@@ -29,7 +29,7 @@ final class SVGView: Macaw.SVGView {
     self.lightSVG = lightSVG
     self.darkSVG = darkSVG
 
-    super.init(node: Group(), frame: .zero)
+    super.init(frame: .zero)
 
     node = svg.node
     backgroundColor = .clear


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Moves light mode / dark mode concerns to `SVGView`
- Adds minimum width specification to SVGs
- Updates the AfterpayBreakdown view when the trait collection changes

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

![2020-08-05 15 07 48](https://user-images.githubusercontent.com/5327203/89376019-4be72e80-d732-11ea-9260-5189f118812f.gif)
