### PR TITLE
Allow the option to implement a delegate and launch the info modal

### DIFF
--- a/Example/Example/Components/ComponentsViewController.swift
+++ b/Example/Example/Components/ComponentsViewController.swift
@@ -46,7 +46,7 @@ final class ComponentsViewController: UIViewController {
     self.view = scrollView
   }
 
-  private final class ContentStackViewController: UIViewController {
+  private final class ContentStackViewController: UIViewController, PriceBreakdownViewDelegate {
 
     let stackTitle: String
 
@@ -85,6 +85,7 @@ final class ComponentsViewController: UIViewController {
       stack.addArrangedSubview(badgeStack)
 
       let priceBreakdown = PriceBreakdownView()
+      priceBreakdown.delegate = self
       stack.addArrangedSubview(priceBreakdown)
 
       let stackConstraints = [
@@ -99,6 +100,8 @@ final class ComponentsViewController: UIViewController {
 
       self.view = view
     }
+
+    func viewControllerForPresentation() -> UIViewController { self }
 
   }
 

--- a/Sources/Afterpay/Info/InfoWebViewController.swift
+++ b/Sources/Afterpay/Info/InfoWebViewController.swift
@@ -34,6 +34,11 @@ final class InfoWebViewController: UIViewController, WKNavigationDelegate {
 
     if #available(iOS 13.0, *) {
       overrideUserInterfaceStyle = .light
+      navigationItem.rightBarButtonItem = UIBarButtonItem(
+        barButtonSystemItem: .close,
+        target: self,
+        action: #selector(dismissViewController)
+      )
     } else {
       navigationItem.rightBarButtonItem = UIBarButtonItem(
         title: "Close",

--- a/Sources/Afterpay/Views/PriceBreakdownView.swift
+++ b/Sources/Afterpay/Views/PriceBreakdownView.swift
@@ -9,7 +9,13 @@
 import Foundation
 import UIKit
 
+public protocol PriceBreakdownViewDelegate: AnyObject {
+  func viewControllerForPresentation() -> UIViewController
+}
+
 public final class PriceBreakdownView: UIView {
+
+  public weak var delegate: PriceBreakdownViewDelegate?
 
   private let linkTextView = LinkTextView()
   private var textColor: UIColor!
@@ -42,7 +48,16 @@ public final class PriceBreakdownView: UIView {
     }
 
     linkTextView.tintColor = linkTintColor
-    linkTextView.linkHandler = { UIApplication.shared.open($0) }
+
+    linkTextView.linkHandler = { [weak self] url in
+      if let viewController = self?.delegate?.viewControllerForPresentation() {
+        let infoWebViewController = InfoWebViewController(infoURL: url)
+        let navigationController = UINavigationController(rootViewController: infoWebViewController)
+        viewController.present(navigationController, animated: true, completion: nil)
+      } else {
+        UIApplication.shared.open(url)
+      }
+    }
 
     updateAttributedText()
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adds `PriceBreakdownViewDelegate`
- Implements `PriceBreakdownViewDelegate` in the Example app
- Opens the web view modally when delegate is implemented and externally otherwise

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

| Delegate Implemented | Delegate not implemented |
| --- | --- |
| ![2020-08-07 16 45 13](https://user-images.githubusercontent.com/5327203/89617337-61449000-d8cd-11ea-9253-cbe817a4fa2c.gif) | ![2020-08-07 16 46 28](https://user-images.githubusercontent.com/5327203/89617459-918c2e80-d8cd-11ea-8922-39a0a32dfb73.gif) |

