### PR TITLE
Add unit tests for PriceBreakdown

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		66D685B224BD3FB900C7287C /* SwiftUIWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D685B124BD3FB900C7287C /* SwiftUIWrapper.swift */; };
 		66DAAC8924E0CE7700127460 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DAAC8824E0CE7700127460 /* Currency.swift */; };
 		66DAAC8B24E0CF0100127460 /* PriceBreakdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DAAC8A24E0CF0100127460 /* PriceBreakdown.swift */; };
+		66DAAC8D24E109D200127460 /* PriceBreakdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DAAC8C24E109D200127460 /* PriceBreakdownTests.swift */; };
 		66EE378724D39FC50029BF42 /* BadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66EE378624D39FC50029BF42 /* BadgeView.swift */; };
 		66EE9BD724DCEC3E00A81C19 /* LinkTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66EE9BD624DCEC3D00A81C19 /* LinkTextView.swift */; };
 		66F9767C2499A11A001D38FA /* Afterpay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F9767B2499A11A001D38FA /* Afterpay.swift */; };
@@ -67,6 +68,7 @@
 		66D685B124BD3FB900C7287C /* SwiftUIWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIWrapper.swift; sourceTree = "<group>"; };
 		66DAAC8824E0CE7700127460 /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		66DAAC8A24E0CF0100127460 /* PriceBreakdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceBreakdown.swift; sourceTree = "<group>"; };
+		66DAAC8C24E109D200127460 /* PriceBreakdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceBreakdownTests.swift; sourceTree = "<group>"; };
 		66EE378624D39FC50029BF42 /* BadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeView.swift; sourceTree = "<group>"; };
 		66EE9BD624DCEC3D00A81C19 /* LinkTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkTextView.swift; sourceTree = "<group>"; };
 		66F9767B2499A11A001D38FA /* Afterpay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Afterpay.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				6635B95E24CAA9F000EBB3A6 /* ConfigurationTests.swift */,
 				665FC57B2488766C00A5A93E /* Info.plist */,
+				66DAAC8C24E109D200127460 /* PriceBreakdownTests.swift */,
 			);
 			path = AfterpayTests;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6635B95F24CAA9F000EBB3A6 /* ConfigurationTests.swift in Sources */,
+				66DAAC8D24E109D200127460 /* PriceBreakdownTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AfterpayTests/PriceBreakdownTests.swift
+++ b/AfterpayTests/PriceBreakdownTests.swift
@@ -11,11 +11,29 @@ import XCTest
 
 class PriceBreakdownTests: XCTestCase {
 
+  override func tearDown() {
+    Afterpay.setConfiguration(nil)
+  }
+
   func testNoConfiguration() {
     let breakdown = PriceBreakdown(totalAmount: .zero)
 
     XCTAssertEqual(breakdown.badgePlacement, .end)
     XCTAssertEqual(breakdown.string, "or pay with")
+  }
+
+  func testInstalments() {
+    let configuration = try? Configuration(
+      minimumAmount: "50.00",
+      maximumAmount: "200.00",
+      currencyCode: "USD")
+
+    configuration.map(Afterpay.setConfiguration)
+
+    let breakdown = PriceBreakdown(totalAmount: 100)
+
+    XCTAssertEqual(breakdown.badgePlacement, .end)
+    XCTAssertEqual(breakdown.string, "or 4 instalments of $25.00 with")
   }
 
 }

--- a/AfterpayTests/PriceBreakdownTests.swift
+++ b/AfterpayTests/PriceBreakdownTests.swift
@@ -1,0 +1,21 @@
+//
+//  PriceBreakdownTests.swift
+//  AfterpayTests
+//
+//  Created by Adam Campbell on 10/8/20.
+//  Copyright © 2020 Afterpay. All rights reserved.
+//
+
+@testable import Afterpay
+import XCTest
+
+class PriceBreakdownTests: XCTestCase {
+
+  func testNoConfiguration() {
+    let breakdown = PriceBreakdown(totalAmount: .zero)
+
+    XCTAssertEqual(breakdown.badgePlacement, .end)
+    XCTAssertEqual(breakdown.string, "or pay with")
+  }
+
+}

--- a/AfterpayTests/PriceBreakdownTests.swift
+++ b/AfterpayTests/PriceBreakdownTests.swift
@@ -37,10 +37,17 @@ class PriceBreakdownTests: XCTestCase {
   func testInstalments() {
     setMinumumMaximumConfiguration()
 
-    let breakdown = PriceBreakdown(totalAmount: 100)
+    let fiftyDollarBreakdown = PriceBreakdown(totalAmount: 50)
+    XCTAssertEqual(fiftyDollarBreakdown.badgePlacement, .end)
+    XCTAssertEqual(fiftyDollarBreakdown.string, "or 4 instalments of $12.50 with")
 
-    XCTAssertEqual(breakdown.badgePlacement, .end)
-    XCTAssertEqual(breakdown.string, "or 4 instalments of $25.00 with")
+    let oneHundredDollarBreakdown = PriceBreakdown(totalAmount: 100)
+    XCTAssertEqual(oneHundredDollarBreakdown.badgePlacement, .end)
+    XCTAssertEqual(oneHundredDollarBreakdown.string, "or 4 instalments of $25.00 with")
+
+    let twoHundredDollarBreakdown = PriceBreakdown(totalAmount: 200)
+    XCTAssertEqual(twoHundredDollarBreakdown.badgePlacement, .end)
+    XCTAssertEqual(twoHundredDollarBreakdown.string, "or 4 instalments of $50.00 with")
   }
 
   func testOutOfRangeWithMinimum() {
@@ -64,6 +71,7 @@ class PriceBreakdownTests: XCTestCase {
     setMaximumConfiguration()
 
     let outOfRangeBreakdowns = [
+      PriceBreakdown(totalAmount: 0),
       PriceBreakdown(totalAmount: 200.01),
       PriceBreakdown(totalAmount: 300),
     ]

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -71,7 +71,7 @@ func getConfiguration() -> Configuration? {
 }
 
 /// Sets the Configuration object to use for rendering UI Components in the Afterpay SDK.
-/// - Parameter configuration: The configuration.
-public func setConfiguration(_ configuration: Configuration) {
+/// - Parameter configuration: The configuration or nil to clear.
+public func setConfiguration(_ configuration: Configuration?) {
   Afterpay.configuration = configuration
 }

--- a/Sources/Afterpay/Model/PriceBreakdown.swift
+++ b/Sources/Afterpay/Model/PriceBreakdown.swift
@@ -16,7 +16,7 @@ private let formatter: NumberFormatter = {
 
 struct PriceBreakdown {
 
-  enum BadgePlacement {
+  enum BadgePlacement: Equatable {
     case start
     case end
   }

--- a/Sources/Afterpay/Model/PriceBreakdown.swift
+++ b/Sources/Afterpay/Model/PriceBreakdown.swift
@@ -32,10 +32,12 @@ struct PriceBreakdown {
     let formattedMaximum = (configuration?.maximumAmount).flatMap(format)
     let formattedInstalment = format(totalAmount / 4)
 
-    let greaterThanMinimum = totalAmount > (configuration?.minimumAmount ?? .zero)
-    let lessThanMaximum = totalAmount < (configuration?.maximumAmount ?? .zero)
+    let greaterThanZero = totalAmount > .zero
+    let greaterThanOrEqualToMinimum = totalAmount >= (configuration?.minimumAmount ?? .zero)
+    let lessThanOrEqualToMaximum = totalAmount <= (configuration?.maximumAmount ?? .zero)
+    let inRange = greaterThanZero && greaterThanOrEqualToMinimum && lessThanOrEqualToMaximum
 
-    if let formattedInstalment = formattedInstalment, greaterThanMinimum && lessThanMaximum {
+    if let formattedInstalment = formattedInstalment, inRange {
       badgePlacement = .end
       string = "or 4 instalments of \(formattedInstalment) with"
     } else if let formattedMinimum = formattedMinimum, let formattedMaximum = formattedMaximum {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Add `PriceBreakdownTests`
- Allow config to be cleared via `Afterpay.setConfiguration(nil)`
