### PR TITLE
Add the ability to view the purchase-payment-agreement in browser

### DIFF
--- a/Sources/Afterpay/Info/InfoWebViewController.swift
+++ b/Sources/Afterpay/Info/InfoWebViewController.swift
@@ -86,6 +86,23 @@ final class InfoWebViewController: UIViewController, WKNavigationDelegate {
     present(alert, animated: true, completion: nil)
   }
 
+  private let externalLinkPathComponents = ["purchase-payment-agreement"]
+
+  func webView(
+    _ webView: WKWebView,
+    decidePolicyFor navigationAction: WKNavigationAction,
+    decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+  ) {
+    let url = navigationAction.request.url
+
+    if let url = url, externalLinkPathComponents.contains(url.lastPathComponent) {
+      decisionHandler(.cancel)
+      UIApplication.shared.open(url)
+    } else {
+      decisionHandler(.allow)
+    }
+  }
+
   // MARK: Unavailable
 
   @available(*, unavailable)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Opens the purchase-payment-agreement web page externally when tapped

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

![2020-08-10 17 07 32](https://user-images.githubusercontent.com/5327203/89758917-53d91100-db2c-11ea-92fc-ceafd5579d6d.gif)