### PR TITLE
Fix scroll view height ambiguity by adding containment views

### DIFF
--- a/Example/Example/Components/ComponentsViewController.swift
+++ b/Example/Example/Components/ComponentsViewController.swift
@@ -13,22 +13,44 @@ import UIKit
 final class ComponentsViewController: UIViewController {
 
   override func loadView() {
-    let scrollView = UIScrollView()
-    scrollView.backgroundColor = .appBackground
+    let view = UIView()
 
-    let layoutGuide = scrollView.readableContentGuide
+    let scrollView = UIScrollView()
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.backgroundColor = .appBackground
+    view.addSubview(scrollView)
+
+    let scrollViewConstraints = [
+      scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+      scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ]
+
+    let contentView = UIView()
+    contentView.translatesAutoresizingMaskIntoConstraints = false
+    scrollView.addSubview(contentView)
+
+    let contentViewConstraints = [
+      contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+      contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+      contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+      contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+      contentView.widthAnchor.constraint(equalTo: view.widthAnchor),
+    ]
 
     let contentStack = UIStackView()
     contentStack.translatesAutoresizingMaskIntoConstraints = false
     contentStack.axis = .vertical
+    contentView.addSubview(contentStack)
 
-    scrollView.addSubview(contentStack)
+    let layoutGuide = contentView.readableContentGuide
 
     let stackConstraints = [
-      contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-      contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+      contentStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      contentStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
       contentStack.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
-      contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+      contentStack.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor),
     ]
 
     install(
@@ -41,9 +63,10 @@ final class ComponentsViewController: UIViewController {
       embed: contentStack.addArrangedSubview
     )
 
-    NSLayoutConstraint.activate(stackConstraints)
+    let constraints = scrollViewConstraints + contentViewConstraints + stackConstraints
+    NSLayoutConstraint.activate(constraints)
 
-    self.view = scrollView
+    self.view = view
   }
 
   private final class ContentStackViewController: UIViewController, PriceBreakdownViewDelegate {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Fixes the example app scroll view

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

| Before | After |
| --- | --- |
| ![2020-08-10 17 25 44](https://user-images.githubusercontent.com/5327203/89759965-9f8cba00-db2e-11ea-9450-09400537fe39.gif) | ![2020-08-10 17 24 04](https://user-images.githubusercontent.com/5327203/89760000-b3d0b700-db2e-11ea-870d-0ad22dc9b5fc.gif) |
