### PR TITLE
Match on Locales to serve the correct "Info" modal

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
 		6615F99B24D14620005036F1 /* SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6615F99A24D14620005036F1 /* SVG.swift */; };
 		661B233224DA8EE70010EBCD /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661B233124DA8EE70010EBCD /* ColorScheme.swift */; };
 		662A3AED24A999A500EFD826 /* CheckoutResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662A3AEC24A999A500EFD826 /* CheckoutResult.swift */; };
@@ -41,6 +42,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
 		6615F99A24D14620005036F1 /* SVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SVG.swift; sourceTree = "<group>"; };
 		661B233124DA8EE70010EBCD /* ColorScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		662A3AEC24A999A500EFD826 /* CheckoutResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutResult.swift; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 			children = (
 				6689536B24C96CB5005090B4 /* Configuration.swift */,
 				66DAAC8824E0CE7700127460 /* Currency.swift */,
+				6605666224E5199500DA588E /* Locales.swift */,
 				66DAAC8A24E0CF0100127460 /* PriceBreakdown.swift */,
 			);
 			path = Model;
@@ -435,6 +438,7 @@
 				946388FE24DD077F00A1227A /* InfoWebViewController.swift in Sources */,
 				66DAAC8924E0CE7700127460 /* Currency.swift in Sources */,
 				66EE9BD724DCEC3E00A81C19 /* LinkTextView.swift in Sources */,
+				6605666324E5199500DA588E /* Locales.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -70,6 +70,12 @@ public func setAuthenticationChallengeHandler(_ handler: @escaping Authenticatio
 
 // MARK: - Configuration
 
+private var locale = Locales.unitedStates
+
+func getLocale() -> Locale {
+  locale
+}
+
 let notificationCenter = NotificationCenter()
 
 extension NSNotification.Name {
@@ -86,5 +92,10 @@ func getConfiguration() -> Configuration? {
 /// - Parameter configuration: The configuration or nil to clear.
 public func setConfiguration(_ configuration: Configuration?) {
   Afterpay.configuration = configuration
+
+  // Currencly the locale for terms of use is strongly tied to the purchasing currency
+  // this will most likely be separated in the future
+  Afterpay.locale = configuration?.currency.locale ?? Locales.unitedStates
+
   notificationCenter.post(name: .configurationUpdated, object: configuration)
 }

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -93,7 +93,7 @@ func getConfiguration() -> Configuration? {
 public func setConfiguration(_ configuration: Configuration?) {
   Afterpay.configuration = configuration
 
-  // Currencly the locale for terms of use is strongly tied to the purchasing currency
+  // Currently the locale for terms of use is strongly tied to the purchasing currency
   // this will most likely be separated in the future
   Afterpay.locale = configuration?.currency.locale ?? Locales.unitedStates
 

--- a/Sources/Afterpay/Info/InfoWebViewController.swift
+++ b/Sources/Afterpay/Info/InfoWebViewController.swift
@@ -86,16 +86,12 @@ final class InfoWebViewController: UIViewController, WKNavigationDelegate {
     present(alert, animated: true, completion: nil)
   }
 
-  private let externalLinkPathComponents = ["terms"]
-
   func webView(
     _ webView: WKWebView,
     decidePolicyFor navigationAction: WKNavigationAction,
     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
   ) {
-    let url = navigationAction.request.url
-
-    if let url = url, externalLinkPathComponents.contains(url.lastPathComponent) {
+    if let url = navigationAction.request.url, url != infoURL {
       decisionHandler(.cancel)
       UIApplication.shared.open(url)
     } else {

--- a/Sources/Afterpay/Info/InfoWebViewController.swift
+++ b/Sources/Afterpay/Info/InfoWebViewController.swift
@@ -86,7 +86,7 @@ final class InfoWebViewController: UIViewController, WKNavigationDelegate {
     present(alert, animated: true, completion: nil)
   }
 
-  private let externalLinkPathComponents = ["purchase-payment-agreement"]
+  private let externalLinkPathComponents = ["terms"]
 
   func webView(
     _ webView: WKWebView,

--- a/Sources/Afterpay/Model/Currency.swift
+++ b/Sources/Afterpay/Model/Currency.swift
@@ -8,11 +8,6 @@
 
 import Foundation
 
-private let posixLocale = Locale(identifier: "en_US_POSIX")
-private let australianLocale = Locale(identifier: "en_AU")
-private let newZealandLocale = Locale(identifier: "en_NZ")
-private let unitedStatesLocale = Locale(identifier: "en_US")
-private let canadianLocale = Locale(identifier: "en_CA")
 private let unknownCurrencyName = "Unknown Currency"
 
 struct Currency {
@@ -21,21 +16,32 @@ struct Currency {
 
   var symbol: String {
     switch code {
-    case australianLocale.currencyCode:
+    case Locales.australia.currencyCode:
       return "A$"
-    case newZealandLocale.currencyCode:
+    case Locales.newZealand.currencyCode:
       return "NZ$"
-    case canadianLocale.currencyCode:
+    case Locales.canada.currencyCode:
       return "CA$"
-    case unitedStatesLocale.currencyCode:
-      fallthrough // swiftlint:disable:this no_fallthrough_only
     default:
       return "$"
     }
   }
 
+  var locale: Locale {
+    switch code {
+    case Locales.australia.currencyCode:
+      return Locales.australia
+    case Locales.newZealand.currencyCode:
+      return Locales.newZealand
+    case Locales.canada.currencyCode:
+      return Locales.canada
+    default:
+      return Locales.unitedStates
+    }
+  }
+
   init?(currencyCode: String) {
-    let currencyName = posixLocale.localizedString(forCurrencyCode: currencyCode)
+    let currencyName = Locales.posix.localizedString(forCurrencyCode: currencyCode)
 
     guard currencyName != nil, currencyName != unknownCurrencyName else {
       return nil

--- a/Sources/Afterpay/Model/Locales.swift
+++ b/Sources/Afterpay/Model/Locales.swift
@@ -1,0 +1,19 @@
+//
+//  Locales.swift
+//  Afterpay
+//
+//  Created by Adam Campbell on 13/8/20.
+//  Copyright © 2020 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+enum Locales {
+
+  static let posix = Locale(identifier: "en_US_POSIX")
+  static let australia = Locale(identifier: "en_AU")
+  static let newZealand = Locale(identifier: "en_NZ")
+  static let unitedStates = Locale(identifier: "en_US")
+  static let canada = Locale(identifier: "en_CA")
+
+}

--- a/Sources/Afterpay/Views/PriceBreakdownView.swift
+++ b/Sources/Afterpay/Views/PriceBreakdownView.swift
@@ -28,6 +28,19 @@ public final class PriceBreakdownView: UIView {
   private var linkColor: UIColor!
   private let colorScheme: ColorScheme
 
+  private var termsLink: String {
+    switch getLocale() {
+    case Locales.australia:
+      return "https://static-us.afterpay.com/javascript/modal/au_rebrand_modal.html"
+    case Locales.newZealand:
+      return "https://static-us.afterpay.com/javascript/modal/nz_rebrand_modal.html"
+    case Locales.canada:
+      return "https://static-us.afterpay.com/javascript/modal/ca_rebrand_modal.html"
+    default:
+      return "https://static-us.afterpay.com/javascript/modal/us_rebrand_modal.html"
+    }
+  }
+
   public init(colorScheme: ColorScheme = .static(.blackOnMint)) {
     self.colorScheme = colorScheme
 
@@ -107,9 +120,6 @@ public final class PriceBreakdownView: UIView {
       .foregroundColor: textColor as UIColor,
     ]
 
-    var linkAttributes = textAttributes
-    linkAttributes[.link] = "https://static-us.afterpay.com/javascript/modal/us_modal.html"
-
     let attributedString = NSMutableAttributedString()
 
     let badge: NSAttributedString = {
@@ -129,6 +139,7 @@ public final class PriceBreakdownView: UIView {
     var badgeAndBreakdown = [badge, space, breakdown]
     badgeAndBreakdown = badgePlacement == .start ? badgeAndBreakdown : badgeAndBreakdown.reversed()
 
+    let linkAttributes = textAttributes.merging([.link: termsLink]) { $1 }
     let link = NSAttributedString(string: Strings.info, attributes: linkAttributes)
     let strings = badgeAndBreakdown + [space, link]
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Holds an internal Locale that is updated in accordance with the user's configuration currency
- Uses the stored locale to show to correct info webpage
