### PR TITLE
Make use of the locale region code to form the info link

### DIFF
--- a/Sources/Afterpay/Views/PriceBreakdownView.swift
+++ b/Sources/Afterpay/Views/PriceBreakdownView.swift
@@ -28,17 +28,9 @@ public final class PriceBreakdownView: UIView {
   private var linkColor: UIColor!
   private let colorScheme: ColorScheme
 
-  private var termsLink: String {
-    switch getLocale() {
-    case Locales.australia:
-      return "https://static-us.afterpay.com/javascript/modal/au_rebrand_modal.html"
-    case Locales.newZealand:
-      return "https://static-us.afterpay.com/javascript/modal/nz_rebrand_modal.html"
-    case Locales.canada:
-      return "https://static-us.afterpay.com/javascript/modal/ca_rebrand_modal.html"
-    default:
-      return "https://static-us.afterpay.com/javascript/modal/us_rebrand_modal.html"
-    }
+  private var infoLink: String {
+    let region = (getLocale().regionCode ?? "US").lowercased()
+    return "https://static-us.afterpay.com/javascript/modal/\(region)_rebrand_modal.html"
   }
 
   public init(colorScheme: ColorScheme = .static(.blackOnMint)) {
@@ -139,7 +131,7 @@ public final class PriceBreakdownView: UIView {
     var badgeAndBreakdown = [badge, space, breakdown]
     badgeAndBreakdown = badgePlacement == .start ? badgeAndBreakdown : badgeAndBreakdown.reversed()
 
-    let linkAttributes = textAttributes.merging([.link: termsLink]) { $1 }
+    let linkAttributes = textAttributes.merging([.link: infoLink]) { $1 }
     let link = NSAttributedString(string: Strings.info, attributes: linkAttributes)
     let strings = badgeAndBreakdown + [space, link]
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Leverage the region code to load the correct modal URL

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

Since there was work in the iOS SDK to set the correct locale we can avoid another switch statement and take the region code of the set locale