### PR TITLE
Fix swiftlint-example script to respect the Mintfile

### DIFF
--- a/Scripts/swiftlint-example
+++ b/Scripts/swiftlint-example
@@ -5,7 +5,10 @@ set -euo pipefail
 # the default SDK for the platform not the one set by the build script
 unset SDKROOT
 
-../Tools/mint/mint run swiftlint \
+# The Mintfile is specified in the directory above
+cd ..
+
+./Tools/mint/mint run swiftlint \
   --quiet \
   --path Example \
-  --config ../../.swiftlint.yml
+  --config ../.swiftlint.yml


### PR DESCRIPTION
## Summary of Changes

Since `swiftlint-example` script was being run from the `Example` directory it wasn't respecting `Mintfile` in the root directory. This PR resolved that issue.