### PR TITLE
Post config updated notification on main thread

### DIFF
--- a/Sources/Afterpay/Views/PriceBreakdownView.swift
+++ b/Sources/Afterpay/Views/PriceBreakdownView.swift
@@ -101,12 +101,18 @@ public final class PriceBreakdownView: UIView {
       linkTextView.bottomAnchor.constraint(equalTo: bottomAnchor),
     ])
 
-    let selector = #selector(updateAttributedText)
+    let selector = #selector(configurationDidChange)
     let name: NSNotification.Name = .configurationUpdated
     notificationCenter.addObserver(self, selector: selector, name: name, object: nil)
   }
 
-  @objc private func updateAttributedText() {
+  @objc private func configurationDidChange() {
+    DispatchQueue.main.async {
+      self.updateAttributedText()
+    }
+  }
+
+  private func updateAttributedText() {
     let configuration = BadgeConfiguration(colorScheme: badgeColorScheme)
     let badgeSVGView = SVGView(svgConfiguration: configuration)
     let svg = badgeSVGView.svg

--- a/Sources/Afterpay/Views/SVGView.swift
+++ b/Sources/Afterpay/Views/SVGView.swift
@@ -66,6 +66,12 @@ final class SVGView: Macaw.SVGView {
   @objc private func configurationDidChange(_ notification: NSNotification) {
     let previousLocale = (notification.object as? Configuration)?.locale ?? Locales.unitedStates
 
+    DispatchQueue.main.async {
+      self.updateSvgLocale(previousLocale: previousLocale)
+    }
+  }
+
+  private func updateSvgLocale(previousLocale: Locale) {
     let svgForLocale = { [traitCollection, svgConfiguration] locale in
       svgConfiguration.svg(localizedFor: locale, withTraits: traitCollection)
     }


### PR DESCRIPTION
Previously, `Afterpay.setConfiguration` was not thread-safe. Calling it would update some UI. Someone calling it on a background thread could cause the SDK to crash.
