### PR TITLE
Add options to cart screen

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		155AD17124AB2464000013B4 /* PurchaseFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155AD17024AB2464000013B4 /* PurchaseFlowController.swift */; };
 		157C65AD25D0F19900115149 /* Result+Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157C65AC25D0F19900115149 /* Result+Fold.swift */; };
 		5539D82C25EDE97E0088BC97 /* ControlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5539D82B25EDE97E0088BC97 /* ControlCell.swift */; };
+		5539D83025F068F90088BC97 /* CheckoutOptionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5539D82F25F068F90088BC97 /* CheckoutOptionsCell.swift */; };
 		660072B724A1B55E00E9A2BC /* TextSettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660072B624A1B55E00E9A2BC /* TextSettingCell.swift */; };
 		6620B5D224934FB3004162BC /* AppFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6620B5D124934FB3004162BC /* AppFlowController.swift */; };
 		663A228E249B030D0027C296 /* MessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663A228D249B030D0027C296 /* MessageViewController.swift */; };
@@ -72,6 +73,7 @@
 		155AD17024AB2464000013B4 /* PurchaseFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseFlowController.swift; sourceTree = "<group>"; };
 		157C65AC25D0F19900115149 /* Result+Fold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+Fold.swift"; sourceTree = "<group>"; };
 		5539D82B25EDE97E0088BC97 /* ControlCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCell.swift; sourceTree = "<group>"; };
+		5539D82F25F068F90088BC97 /* CheckoutOptionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutOptionsCell.swift; sourceTree = "<group>"; };
 		660072B624A1B55E00E9A2BC /* TextSettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSettingCell.swift; sourceTree = "<group>"; };
 		6620B5D124934FB3004162BC /* AppFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowController.swift; sourceTree = "<group>"; };
 		663A228D249B030D0027C296 /* MessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageViewController.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				66BD11AF24ADB0F300039DA6 /* CartDisplay.swift */,
 				66BD11AD24ADA94800039DA6 /* CartViewController.swift */,
 				1535ACB625DBA8AD00727818 /* CheckoutHandler.swift */,
+				5539D82F25F068F90088BC97 /* CheckoutOptionsCell.swift */,
 				66BD11B124ADB62700039DA6 /* CurrencyFormatter.swift */,
 				66E6FDA524AC377D00ED81E8 /* Product.swift */,
 				665311C224AC23D10088A063 /* ProductCell.swift */,
@@ -391,6 +394,7 @@
 				66D685B524BD7ABF00C7287C /* SwiftUIExample.swift in Sources */,
 				9490D1D624D8ED4F001E1EFC /* Repository.swift in Sources */,
 				66F2D8BA24A0415700F65621 /* WindowHolder.swift in Sources */,
+				5539D83025F068F90088BC97 /* CheckoutOptionsCell.swift in Sources */,
 				157C65AD25D0F19900115149 /* Result+Fold.swift in Sources */,
 				66BD11AE24ADA94800039DA6 /* CartViewController.swift in Sources */,
 				948F664824B6E95900DC0202 /* SegmentedSettingCell.swift in Sources */,

--- a/Example/Example/Purchase/CartDisplay.swift
+++ b/Example/Example/Purchase/CartDisplay.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Afterpay. All rights reserved.
 //
 
+import Afterpay
 import Foundation
 
 struct CartDisplay {
@@ -14,14 +15,16 @@ struct CartDisplay {
   let message: String?
   let displayTotal: String
   let payEnabled: Bool
+  let initialCheckoutOptions: CheckoutV2Options
 
-  init(products: [ProductDisplay], total: Decimal, currencyCode: String) {
+  init(products: [ProductDisplay], total: Decimal, currencyCode: String, initialCheckoutOptions: CheckoutV2Options) {
     self.products = products
     self.message = products.isEmpty ? "Please add some items to your cart." : nil
     self.payEnabled = products.isEmpty ? false : true
 
     let formatter = CurrencyFormatter(currencyCode: currencyCode)
     self.displayTotal = formatter.displayString(from: total)
+    self.initialCheckoutOptions = initialCheckoutOptions
   }
 
 }

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -21,7 +21,7 @@ final class CartViewController: UIViewController, UITableViewDataSource {
 
   enum Event {
     case didTapPay
-    case optionsChanged(buyNow: Bool)
+    case optionsChanged(CheckoutOptionsCell.Event)
   }
 
   init(cart: CartDisplay, eventHandler: @escaping (Event) -> Void) {
@@ -128,7 +128,10 @@ final class CartViewController: UIViewController, UITableViewDataSource {
         withIdentifier: checkoutOptionsCellIdentifier,
         for: indexPath) as! CheckoutOptionsCell
 
-      optionsCell.configure(eventHandler: { self.eventHandler(.optionsChanged(buyNow: $0)) })
+      optionsCell.configure(
+        initialOptions: cart.initialCheckoutOptions,
+        eventHandler: { self.eventHandler(.optionsChanged($0)) }
+      )
 
       cell = optionsCell
     }

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -20,6 +20,7 @@ final class CartViewController: UIViewController, UITableViewDataSource {
 
   enum Event {
     case didTapPay
+    case optionsChanged(buyNow: Bool)
   }
 
   init(cart: CartDisplay, eventHandler: @escaping (Event) -> Void) {

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -72,10 +72,10 @@ final class CartViewController: UIViewController, UITableViewDataSource {
   // MARK: UITableViewDataSource
 
   private enum Section: Int, CaseIterable {
-    case message, products, total
+    case message, products, total, options
 
     static func from(section: Int) -> Section {
-      Section(rawValue: section)!
+      Section.allCases[section]
     }
   }
 
@@ -90,6 +90,8 @@ final class CartViewController: UIViewController, UITableViewDataSource {
     case .products:
       return cart.products.count
     case .total:
+      return 1
+    case .options:
       return 1
     }
   }
@@ -117,6 +119,9 @@ final class CartViewController: UIViewController, UITableViewDataSource {
         for: indexPath) as! TitleSubtitleCell
       titleSubtitleCell.configure(title: "Total", subtitle: cart.displayTotal)
       cell = titleSubtitleCell
+
+    case .options:
+      cell = UITableViewCell()
     }
 
     return cell

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -15,6 +15,7 @@ final class CartViewController: UIViewController, UITableViewDataSource {
   private let cart: CartDisplay
   private let genericCellIdentifier = String(describing: UITableViewCell.self)
   private let productCellIdentifier = String(describing: ProductCell.self)
+  private let checkoutOptionsCellIdentifier = String(describing: CheckoutOptionsCell.self)
   private let titleSubtitleCellIdentifier = String(describing: TitleSubtitleCell.self)
   private let eventHandler: (Event) -> Void
 
@@ -44,6 +45,7 @@ final class CartViewController: UIViewController, UITableViewDataSource {
     tableView.translatesAutoresizingMaskIntoConstraints = false
     tableView.register(UITableViewCell.self, forCellReuseIdentifier: genericCellIdentifier)
     tableView.register(ProductCell.self, forCellReuseIdentifier: productCellIdentifier)
+    tableView.register(CheckoutOptionsCell.self, forCellReuseIdentifier: checkoutOptionsCellIdentifier)
     tableView.register(TitleSubtitleCell.self, forCellReuseIdentifier: titleSubtitleCellIdentifier)
 
     let payButton: UIButton = PaymentButton()
@@ -122,7 +124,13 @@ final class CartViewController: UIViewController, UITableViewDataSource {
       cell = titleSubtitleCell
 
     case .options:
-      cell = UITableViewCell()
+      let optionsCell = tableView.dequeueReusableCell(
+        withIdentifier: checkoutOptionsCellIdentifier,
+        for: indexPath) as! CheckoutOptionsCell
+
+      optionsCell.configure(eventHandler: { self.eventHandler(.optionsChanged(buyNow: $0)) })
+
+      cell = optionsCell
     }
 
     return cell

--- a/Example/Example/Purchase/CheckoutOptionsCell.swift
+++ b/Example/Example/Purchase/CheckoutOptionsCell.swift
@@ -1,0 +1,58 @@
+//
+//  CheckoutOptionsCell.swift
+//  Example
+//
+//  Created by Huw Rowlands on 4/3/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+final class CheckoutOptionsCell: UITableViewCell {
+
+  private let buyNowLabel = UILabel()
+  private let buyNowSwitch = UISwitch()
+
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    buyNowLabel.text = "Buy now"
+    buyNowSwitch.isOn = false
+    buyNowSwitch.addTarget(self, action: #selector(buyNowToggled), for: .valueChanged)
+
+    let buyNowStack = UIStackView(
+      arrangedSubviews: [buyNowLabel, buyNowSwitch]
+    )
+
+    buyNowStack.translatesAutoresizingMaskIntoConstraints = false
+
+    contentView.addSubview(buyNowStack)
+
+    let layoutGuide = contentView.readableContentGuide
+
+    NSLayoutConstraint.activate([
+      buyNowStack.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
+      buyNowStack.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
+      buyNowStack.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor),
+      buyNowStack.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor),
+    ])
+  }
+
+  func configure(eventHandler: ((Bool) -> Void)? = nil) {
+    self.eventHandler = eventHandler
+  }
+
+  var eventHandler: ((Bool) -> Void)?
+
+  @objc private func buyNowToggled() {
+    eventHandler?(buyNowSwitch.isOn)
+  }
+
+  // MARK: Unavailable
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+}

--- a/Example/Example/Purchase/CheckoutOptionsCell.swift
+++ b/Example/Example/Purchase/CheckoutOptionsCell.swift
@@ -6,46 +6,102 @@
 //  Copyright © 2021 Afterpay. All rights reserved.
 //
 
+import Afterpay
 import Foundation
 
 final class CheckoutOptionsCell: UITableViewCell {
 
-  private let buyNowLabel = UILabel()
-  private let buyNowSwitch = UISwitch()
+  let buyNowLabel = UILabel()
+  let buyNowSwitch = UISwitch()
+
+  let pickupLabel = UILabel()
+  let pickupSwitch = UISwitch()
+
+  let shippingOptionRequiredLabel = UILabel()
+  let shippingOptionRequiredSwitch = UISwitch()
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+    let title = UILabel()
+    title.font = .preferredFont(forTextStyle: .headline)
+    title.text = "Checkout options"
+
     buyNowLabel.text = "Buy now"
-    buyNowSwitch.isOn = false
     buyNowSwitch.addTarget(self, action: #selector(buyNowToggled), for: .valueChanged)
 
-    let buyNowStack = UIStackView(
-      arrangedSubviews: [buyNowLabel, buyNowSwitch]
+    pickupLabel.text = "Pickup"
+    pickupSwitch.addTarget(self, action: #selector(pickupToggled), for: .valueChanged)
+
+    shippingOptionRequiredLabel.text = "Shipping option required"
+    shippingOptionRequiredSwitch.addTarget(
+      self, action: #selector(shippingOptionRequiredToggled), for: .valueChanged
     )
 
-    buyNowStack.translatesAutoresizingMaskIntoConstraints = false
+    let verticalStack = UIStackView(
+      arrangedSubviews: [
+        title,
+        UIStackView(arrangedSubviews: [buyNowLabel, buyNowSwitch]),
+        UIStackView(arrangedSubviews: [pickupLabel, pickupSwitch]),
+        UIStackView(arrangedSubviews: [shippingOptionRequiredLabel, shippingOptionRequiredSwitch]),
+      ]
+    )
 
-    contentView.addSubview(buyNowStack)
+    verticalStack.axis = .vertical
+    verticalStack.spacing = 8
+    verticalStack.translatesAutoresizingMaskIntoConstraints = false
+
+    contentView.addSubview(verticalStack)
 
     let layoutGuide = contentView.readableContentGuide
 
     NSLayoutConstraint.activate([
-      buyNowStack.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
-      buyNowStack.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
-      buyNowStack.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor),
-      buyNowStack.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor),
+      verticalStack.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
+      verticalStack.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
+      verticalStack.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor),
+      verticalStack.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor),
     ])
   }
 
-  func configure(eventHandler: ((Bool) -> Void)? = nil) {
+  private static func makeStack(title: String, target: CheckoutOptionsCell, toggleAction: Selector) -> UIStackView {
+    let label = UILabel()
+    label.text = title
+
+    let switchControl = UISwitch()
+    switchControl.isOn = false
+    switchControl.addTarget(target, action: toggleAction, for: .valueChanged)
+
+    return UIStackView(arrangedSubviews: [label, switchControl])
+  }
+
+  // MARK: Actions
+
+  enum Event {
+    case buyNow
+    case pickup
+    case shippingOptionRequired
+  }
+
+  func configure(initialOptions: CheckoutV2Options, eventHandler: ((Event) -> Void)? = nil) {
+    buyNowSwitch.isOn = initialOptions.buyNow ?? false
+    pickupSwitch.isOn = initialOptions.pickup ?? false
+    shippingOptionRequiredSwitch.isOn = initialOptions.shippingOptionRequired ?? true
+
     self.eventHandler = eventHandler
   }
 
-  var eventHandler: ((Bool) -> Void)?
+  private var eventHandler: ((Event) -> Void)?
 
-  @objc private func buyNowToggled() {
-    eventHandler?(buyNowSwitch.isOn)
+  @objc public func buyNowToggled() {
+    eventHandler?(.buyNow)
+  }
+
+  @objc public func pickupToggled() {
+    eventHandler?(.pickup)
+  }
+
+  @objc public func shippingOptionRequiredToggled() {
+    eventHandler?(.shippingOptionRequired)
   }
 
   // MARK: Unavailable

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -57,6 +57,7 @@ final class PurchaseFlowController: UIViewController {
     }
   }
 
+  // swiftlint:disable:next cyclomatic_complexity
   private func execute(command: PurchaseLogicController.Command) {
     let logicController = self.logicController
     let navigationController = self.ownedNavigationController
@@ -70,8 +71,12 @@ final class PurchaseFlowController: UIViewController {
         switch event {
         case .didTapPay:
           logicController.payWithAfterpay()
-        case .optionsChanged(let buyNow):
-          logicController.buyNow = buyNow
+        case .optionsChanged(.buyNow):
+          logicController.toggleOption(\.buyNow)
+        case .optionsChanged(.pickup):
+          logicController.toggleOption(\.pickup)
+        case .optionsChanged(.shippingOptionRequired):
+          logicController.toggleOption(\.shippingOptionRequired)
         }
       }
 

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -75,8 +75,8 @@ final class PurchaseFlowController: UIViewController {
 
       navigationController.pushViewController(cartViewController, animated: true)
 
-    case .showAfterpayCheckout:
-      Afterpay.presentCheckoutV2Modally(over: ownedNavigationController) { result in
+    case .showAfterpayCheckout(let options):
+      Afterpay.presentCheckoutV2Modally(over: ownedNavigationController, options: options) { result in
         switch result {
         case .success(let token):
           logicController.success(with: token)

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -70,6 +70,8 @@ final class PurchaseFlowController: UIViewController {
         switch event {
         case .didTapPay:
           logicController.payWithAfterpay()
+        case .optionsChanged(let buyNow):
+          logicController.buyNow = buyNow
         }
       }
 

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -41,8 +41,11 @@ final class PurchaseLogicController {
 
   private var quantities: [UUID: UInt] = [:]
 
-  //TODO: more complex type later holding more options
-  var buyNow = false
+  private var checkoutOptions = CheckoutV2Options(
+    pickup: false,
+    buyNow: false,
+    shippingOptionRequired: true
+  )
 
   private var productDisplayModels: [ProductDisplay] {
     ProductDisplay.products(products, quantities: quantities, currencyCode: currencyCode)
@@ -77,14 +80,24 @@ final class PurchaseLogicController {
     commandHandler(.updateProducts(productDisplayModels))
   }
 
+  func toggleOption(_ option: WritableKeyPath<CheckoutV2Options, Bool?>) {
+    let currentValue = checkoutOptions[keyPath: option] ?? false
+    checkoutOptions[keyPath: option] = !currentValue
+  }
+
   func viewCart() {
     let productsInCart = productDisplayModels.filter { (quantities[$0.id] ?? 0) > 0 }
-    let cart = CartDisplay(products: productsInCart, total: total, currencyCode: currencyCode)
+    let cart = CartDisplay(
+      products: productsInCart, total: total, currencyCode: currencyCode,
+      initialCheckoutOptions: checkoutOptions
+    )
     commandHandler(.showCart(cart))
   }
 
   func payWithAfterpay() {
-    commandHandler(.showAfterpayCheckout(CheckoutV2Options(buyNow: buyNow)))
+    commandHandler(
+      .showAfterpayCheckout(checkoutOptions)
+    )
   }
 
   func loadCheckout() {

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -14,7 +14,7 @@ final class PurchaseLogicController {
   enum Command {
     case updateProducts([ProductDisplay])
     case showCart(CartDisplay)
-    case showAfterpayCheckout
+    case showAfterpayCheckout(CheckoutV2Options)
     case provideCheckoutTokenResult(TokenResult)
     case provideShippingOptionsResult(ShippingOptionsResult)
     case showAlertForErrorMessage(String)
@@ -40,6 +40,9 @@ final class PurchaseLogicController {
   private var currencyCode: String { configurationProvider().currencyCode }
 
   private var quantities: [UUID: UInt] = [:]
+
+  //TODO: more complex type later holding more options
+  var buyNow = false
 
   private var productDisplayModels: [ProductDisplay] {
     ProductDisplay.products(products, quantities: quantities, currencyCode: currencyCode)
@@ -81,7 +84,7 @@ final class PurchaseLogicController {
   }
 
   func payWithAfterpay() {
-    commandHandler(.showAfterpayCheckout)
+    commandHandler(.showAfterpayCheckout(CheckoutV2Options(buyNow: buyNow)))
   }
 
   func loadCheckout() {


### PR DESCRIPTION
Let's add options to configure the `CheckoutV2Options` on the cart screen:

<img src="https://user-images.githubusercontent.com/790199/109912445-348c1600-7d00-11eb-9ca4-ca78578a2516.png" width="350">

## Summary of Changes

- The logic controller is the source of truth, and has a `CheckoutV2Options` value.
- Add a cell on the CartViewController which contains three swithes: one for each of the options.
- When you tap one, it calls back to the logic controller (via event handlers) to toggle options on and off. 
- When it launches the checkout, it sends those options along.

## Items of Note

This will be handy, not just for testers, but for developers. It will be even handier when we get up to adding the deferred shipping options. We can use this, or a similar technique.

## Submission Checklist

This change is only inside the Example app.
