### PR TITLE
Update locale structure to look for identifier

### DIFF
--- a/Example/Example/Shared/APIClient.swift
+++ b/Example/Example/Shared/APIClient.swift
@@ -24,7 +24,11 @@ struct CheckoutsResponse: Decodable {
 struct ConfigurationResponse: Codable {
   let minimumAmount: Money?
   let maximumAmount: Money
-  let locale: String
+  let locale: LocaleResponse
+
+  struct LocaleResponse: Codable {
+    let identifier: String
+  }
 
   struct Money: Codable {
     let amount: String

--- a/Example/Example/Shared/Repository.swift
+++ b/Example/Example/Shared/Repository.swift
@@ -112,7 +112,7 @@ final class Repository {
         minimumAmount: response.minimumAmount?.amount,
         maximumAmount: response.maximumAmount.amount,
         currencyCode: response.maximumAmount.currency,
-        locale: Locale(identifier: response.locale),
+        locale: Locale(identifier: response.locale.identifier),
         environment: environment
       )
     }


### PR DESCRIPTION
The SDK example server started sending back the locale as an object with a few things in it. These are for Android, mainly. We will just get the identifier out. That’ll be the same behaviour as we had before.

## Summary of Changes

- Look for identifier inside the locale in the example server's config response

## Items of Note

* This is the PR where the example server changed: https://github.com/afterpay/sdk-example-server/pull/23
