### PR TITLE
Add features struct, with widget enabled feature

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		157E88D125CBCA49007E54C4 /* Result+Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157E88D025CBCA49007E54C4 /* Result+Fold.swift */; };
 		15EC67D225E6217F007DFEA8 /* OSLog+Afterpay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EC67D125E6217F007DFEA8 /* OSLog+Afterpay.swift */; };
 		15F7DDB725393BD30011EC25 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */; };
+		551BEDEB25F983E200FDF9EE /* Features.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDEA25F983E200FDF9EE /* Features.swift */; };
+		551BEDF125F98FA800FDF9EE /* FeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
 		6615F99B24D14620005036F1 /* SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6615F99A24D14620005036F1 /* SVG.swift */; };
@@ -66,6 +68,8 @@
 		15EC67D125E6217F007DFEA8 /* OSLog+Afterpay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSLog+Afterpay.swift"; sourceTree = "<group>"; };
 		15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		15FAC56625DCCEDF00DE7792 /* Afterpay.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Afterpay.podspec; sourceTree = "<group>"; };
+		551BEDEA25F983E200FDF9EE /* Features.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features.swift; sourceTree = "<group>"; };
+		551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesTests.swift; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
 		6615F99A24D14620005036F1 /* SVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SVG.swift; sourceTree = "<group>"; };
@@ -186,6 +190,7 @@
 			children = (
 				6635B95E24CAA9F000EBB3A6 /* ConfigurationTests.swift */,
 				66C3F7FA25397A810086DD0A /* CurrencyFormatterTests.swift */,
+				551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */,
 				665FC57B2488766C00A5A93E /* Info.plist */,
 				66DAAC8C24E109D200127460 /* PriceBreakdownTests.swift */,
 			);
@@ -238,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				66F9767B2499A11A001D38FA /* Afterpay.swift */,
+				551BEDEA25F983E200FDF9EE /* Features.swift */,
 				946388FB24DD05D400A1227A /* Checkout */,
 				157E88CF25CBCA22007E54C4 /* Helpers */,
 				946388FC24DD075400A1227A /* Info */,
@@ -471,6 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				551BEDF125F98FA800FDF9EE /* FeaturesTests.swift in Sources */,
 				6635B95F24CAA9F000EBB3A6 /* ConfigurationTests.swift in Sources */,
 				66DAAC8D24E109D200127460 /* PriceBreakdownTests.swift in Sources */,
 				66C3F7FB25397A810086DD0A /* CurrencyFormatterTests.swift in Sources */,
@@ -502,6 +509,7 @@
 				66B54588256B3FD9002B3DD5 /* CheckoutV2ViewController.swift in Sources */,
 				667AD3542497121200BF94E5 /* CheckoutWebViewController.swift in Sources */,
 				15EC67D225E6217F007DFEA8 /* OSLog+Afterpay.swift in Sources */,
+				551BEDEB25F983E200FDF9EE /* Features.swift in Sources */,
 				66F9767C2499A11A001D38FA /* Afterpay.swift in Sources */,
 				151A4FEB258C1F8A0046CEEE /* StaticContent.swift in Sources */,
 				66EE378724D39FC50029BF42 /* BadgeView.swift in Sources */,

--- a/AfterpayTests/FeaturesTests.swift
+++ b/AfterpayTests/FeaturesTests.swift
@@ -1,0 +1,22 @@
+//
+//  FeaturesTests.swift
+//  AfterpayTests
+//
+//  Created by Huw Rowlands on 11/3/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+@testable import Afterpay
+import XCTest
+
+class FeaturesTests: XCTestCase {
+
+  func testWidgetEnabledIsOffByDefault() {
+    XCTAssertFalse(Features.widgetEnabled)
+
+    UserDefaults.standard.setVolatileDomain(["com.afterpay.widget-enabled": true], forName: UserDefaults.argumentDomain)
+
+    XCTAssertTrue(Features.widgetEnabled)
+  }
+
+}

--- a/Sources/Afterpay/Features.swift
+++ b/Sources/Afterpay/Features.swift
@@ -1,0 +1,18 @@
+//
+//  Features.swift
+//  Afterpay
+//
+//  Created by Huw Rowlands on 11/3/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+struct Features {
+
+  /// Is the checkout widget enabled?
+  static var widgetEnabled: Bool {
+    UserDefaults.standard.bool(forKey: "com.afterpay.widget-enabled")
+  }
+
+}


### PR DESCRIPTION
Previously, there was no way to have feature flags in the SDK. Now, we are using the defaults parsed from the app’s arguments on launch.

With these arguments are passed on app launch: `-com.afterpay.widget-enabled YES`, the SDK will have the `widgetEnabled` feature toggle turned on. If it’s not passed, it is off by default.

Currently, no behaviour is based on this feature flag. Soon, it will be used to turn on the checkout widget.

## Summary of Changes

- Add `Features` struct, which is internal to the SDK code.
- Add `widgetEnabled` feature flag, which can be turned on by passing the `-com.afterpay.widget-enabled YES` arguments on app launch.

## Submission Checklist

- [x] Tests are included.
- [x] Documentation is changed or added.
