### PR TITLE
Remove script handler on view dismissal

### DIFF
--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -113,6 +113,11 @@ final class CheckoutV2ViewController:
     self.view = view
   }
 
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    bootstrapWebView.configuration.userContentController.removeScriptMessageHandler(forName: "iOS")
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 


### PR DESCRIPTION
While loading the view, we make the `CheckoutV2ViewController` its own message handler with: `userContentController.add(self, name: "iOS”)`. This retains the view controller, and causes a memory leak.

We should remove the script message handler when its no longer needed. Since we setup the handler in `loadView`, we should remove it in `viewWillDisappear`.

## Summary of Changes

- Fix memory leak in `CheckoutV2ViewController`

## Reproduction steps

- Set breakpoint in `CheckoutV2ViewController`'s `deinit` function.
- Open and dismiss `CheckoutV2ViewController` repeatedly.

Expected: 
- You hit the breakpoint

Actual:
- You do not. Multiple instances of the view controller are visible in the memory debugger.

