### PR TITLE
Add `WidgetView`, and send it events

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		15F7DDB725393BD30011EC25 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */; };
 		551BEDEB25F983E200FDF9EE /* Features.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDEA25F983E200FDF9EE /* Features.swift */; };
 		551BEDF125F98FA800FDF9EE /* FeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */; };
+		551BEDF825F9B95C00FDF9EE /* WidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDF725F9B95C00FDF9EE /* WidgetView.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
 		6615F99B24D14620005036F1 /* SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6615F99A24D14620005036F1 /* SVG.swift */; };
@@ -70,6 +71,7 @@
 		15FAC56625DCCEDF00DE7792 /* Afterpay.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Afterpay.podspec; sourceTree = "<group>"; };
 		551BEDEA25F983E200FDF9EE /* Features.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features.swift; sourceTree = "<group>"; };
 		551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesTests.swift; sourceTree = "<group>"; };
+		551BEDF725F9B95C00FDF9EE /* WidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetView.swift; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
 		6615F99A24D14620005036F1 /* SVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SVG.swift; sourceTree = "<group>"; };
@@ -144,6 +146,14 @@
 				157E88D025CBCA49007E54C4 /* Result+Fold.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		551BEDF625F9B92A00FDF9EE /* Widget */ = {
+			isa = PBXGroup;
+			children = (
+				551BEDF725F9B95C00FDF9EE /* WidgetView.swift */,
+			);
+			path = Widget;
 			sourceTree = "<group>";
 		};
 		661B233024DA87EA0010EBCD /* Views */ = {
@@ -250,6 +260,7 @@
 				6691776D24E0CB7C00D0A4B2 /* Model */,
 				66E255AC24E3BA2000C81F20 /* Resources */,
 				661B233024DA87EA0010EBCD /* Views */,
+				551BEDF625F9B92A00FDF9EE /* Widget */,
 				663F96AA24DA906800B0643A /* Wrappers */,
 			);
 			name = Sources;
@@ -259,13 +270,13 @@
 		6691776D24E0CB7C00D0A4B2 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				661D431E257DC86C00ACCDE1 /* ShippingAddress.swift */,
 				662A3AEC24A999A500EFD826 /* CheckoutResult.swift */,
 				6689536B24C96CB5005090B4 /* Configuration.swift */,
 				15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */,
 				1522245F25C925E5004B9CE5 /* Environment.swift */,
 				6605666224E5199500DA588E /* Locales.swift */,
 				66DAAC8A24E0CF0100127460 /* PriceBreakdown.swift */,
+				661D431E257DC86C00ACCDE1 /* ShippingAddress.swift */,
 				661D4322257DF1CB00ACCDE1 /* ShippingOption.swift */,
 				157C65AE25D23E8F00115149 /* Version.swift */,
 			);
@@ -502,6 +513,7 @@
 				66DAAC8B24E0CF0100127460 /* PriceBreakdown.swift in Sources */,
 				661CFDB62570E7F000D8A1E8 /* PaymentButton.swift in Sources */,
 				662A3AED24A999A500EFD826 /* CheckoutResult.swift in Sources */,
+				551BEDF825F9B95C00FDF9EE /* WidgetView.swift in Sources */,
 				1522246025C925E5004B9CE5 /* Environment.swift in Sources */,
 				66996F672580A5BE0061C365 /* CheckoutV2Completion.swift in Sources */,
 				157C65AF25D23E8F00115149 /* Version.swift in Sources */,

--- a/Afterpay.xcodeproj/xcshareddata/xcschemes/Afterpay.xcscheme
+++ b/Afterpay.xcodeproj/xcshareddata/xcschemes/Afterpay.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Afterpay.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "665FC5762488766C00A5A93E"
+               BuildableName = "AfterpayTests.xctest"
+               BlueprintName = "AfterpayTests"
+               ReferencedContainer = "container:Afterpay.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/AfterpayTests/FeaturesTests.swift
+++ b/AfterpayTests/FeaturesTests.swift
@@ -12,11 +12,11 @@ import XCTest
 class FeaturesTests: XCTestCase {
 
   func testWidgetEnabledIsOffByDefault() {
-    XCTAssertFalse(Features.widgetEnabled)
+    XCTAssertFalse(AfterpayFeatures.widgetEnabled)
 
     UserDefaults.standard.setVolatileDomain(["com.afterpay.widget-enabled": true], forName: UserDefaults.argumentDomain)
 
-    XCTAssertTrue(Features.widgetEnabled)
+    XCTAssertTrue(AfterpayFeatures.widgetEnabled)
   }
 
 }

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.afterpay.widget-enabled YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -102,8 +102,8 @@ final class PurchaseFlowController: UIViewController {
       let alert = AlertFactory.alert(for: errorMessage)
       navigationController.present(alert, animated: true, completion: nil)
 
-    case .showSuccessWithMessage(let message):
-      let messageViewController = MessageViewController(message: message)
+    case .showSuccessWithMessage(let message, let token):
+      let messageViewController = MessageViewController(message: message, token: token)
       let viewControllers = [productsViewController, messageViewController]
       navigationController.setViewControllers(viewControllers, animated: true)
     }

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -18,7 +18,7 @@ final class PurchaseLogicController {
     case provideCheckoutTokenResult(TokenResult)
     case provideShippingOptionsResult(ShippingOptionsResult)
     case showAlertForErrorMessage(String)
-    case showSuccessWithMessage(String)
+    case showSuccessWithMessage(String, Token)
   }
 
   var commandHandler: (Command) -> Void = { _ in } {
@@ -135,7 +135,7 @@ final class PurchaseLogicController {
   func success(with token: String) {
     quantities = [:]
     commandHandler(.updateProducts(productDisplayModels))
-    commandHandler(.showSuccessWithMessage("Success with: \(token)"))
+    commandHandler(.showSuccessWithMessage("Success", token))
   }
 
   func cancelled(with reason: CheckoutResult.CancellationReason) {

--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Afterpay. All rights reserved.
 //
 
-import Foundation
+import Afterpay
 import UIKit
 
 final class MessageViewController: UIViewController {
@@ -28,6 +28,7 @@ final class MessageViewController: UIViewController {
     view.backgroundColor = .appBackground
 
     setupMessageLabel()
+    setupWidget()
   }
 
   private func setupMessageLabel() {
@@ -50,6 +51,27 @@ final class MessageViewController: UIViewController {
     ]
 
     NSLayoutConstraint.activate(labelConstraints)
+  }
+
+  private func setupWidget() {
+    guard AfterpayFeatures.widgetEnabled else { return }
+
+    let widgetView = WidgetView(token: token)
+
+    view.addSubview(widgetView)
+
+    let layoutGuide = view.safeAreaLayoutGuide
+
+    widgetView.translatesAutoresizingMaskIntoConstraints = false
+
+    let constraints = [
+      widgetView.topAnchor.constraint(equalTo: messageLabel.topAnchor, constant: 32),
+      widgetView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
+      widgetView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
+      widgetView.heightAnchor.constraint(equalToConstant: 350),
+    ]
+
+    NSLayoutConstraint.activate(constraints)
   }
 
   // MARK: Unavailable

--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -14,9 +14,11 @@ final class MessageViewController: UIViewController {
   private var messageLabel = UILabel()
 
   private let message: String
+  private let token: Token
 
-  init(message: String) {
+  init(message: String, token: Token) {
     self.message = message
+    self.token = token
 
     super.init(nibName: nil, bundle: nil)
   }

--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -27,6 +27,10 @@ final class MessageViewController: UIViewController {
     view = UIView()
     view.backgroundColor = .appBackground
 
+    setupMessageLabel()
+  }
+
+  private func setupMessageLabel() {
     messageLabel.text = message
     messageLabel.font = .preferredFont(forTextStyle: .body)
     messageLabel.adjustsFontForContentSizeCategory = true
@@ -40,8 +44,8 @@ final class MessageViewController: UIViewController {
     let layoutGuide = view.safeAreaLayoutGuide
 
     let labelConstraints = [
-      messageLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
       messageLabel.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 16),
+      messageLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
       messageLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
     ]
 

--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -12,6 +12,8 @@ import UIKit
 final class MessageViewController: UIViewController {
 
   private var messageLabel = UILabel()
+  private var widgetView: WidgetView!
+  private let updateButton = UIButton(type: .system)
 
   private let message: String
   private let token: Token
@@ -29,6 +31,7 @@ final class MessageViewController: UIViewController {
 
     setupMessageLabel()
     setupWidget()
+    setupWidgetUpdateButton()
   }
 
   private func setupMessageLabel() {
@@ -56,13 +59,12 @@ final class MessageViewController: UIViewController {
   private func setupWidget() {
     guard AfterpayFeatures.widgetEnabled else { return }
 
-    let widgetView = WidgetView(token: token)
+    widgetView = WidgetView(token: token)
+    widgetView.translatesAutoresizingMaskIntoConstraints = false
 
     view.addSubview(widgetView)
 
     let layoutGuide = view.safeAreaLayoutGuide
-
-    widgetView.translatesAutoresizingMaskIntoConstraints = false
 
     let constraints = [
       widgetView.topAnchor.constraint(equalTo: messageLabel.topAnchor, constant: 32),
@@ -72,6 +74,35 @@ final class MessageViewController: UIViewController {
     ]
 
     NSLayoutConstraint.activate(constraints)
+  }
+
+  private func setupWidgetUpdateButton() {
+    guard AfterpayFeatures.widgetEnabled else { return }
+
+    updateButton.setTitle("Update widget", for: .normal)
+    updateButton.translatesAutoresizingMaskIntoConstraints = false
+    updateButton.addTarget(self, action: #selector(updateTapped), for: .touchUpInside)
+    updateButton.translatesAutoresizingMaskIntoConstraints = false
+
+    view.addSubview(updateButton)
+
+    let layoutGuide = view.safeAreaLayoutGuide
+
+    let constraints = [
+      updateButton.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
+      updateButton.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
+      updateButton.topAnchor.constraint(equalTo: widgetView.bottomAnchor, constant: 16),
+    ]
+
+    NSLayoutConstraint.activate(constraints)
+  }
+
+  @objc private func updateTapped() {
+    let randomDouble = Double.random(in: 0..<99)
+
+    widgetView.sendUpdate(
+      amount: String(format: "%.2f", randomDouble)
+    )
   }
 
   // MARK: Unavailable

--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class MessageViewController: UIViewController {
 
-  private var label: UILabel { view as! UILabel }
+  private var messageLabel = UILabel()
 
   private let message: String
 
@@ -22,19 +22,28 @@ final class MessageViewController: UIViewController {
   }
 
   override func loadView() {
-    view = UILabel()
-  }
+    view = UIView()
+    view.backgroundColor = .appBackground
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    messageLabel.text = message
+    messageLabel.font = .preferredFont(forTextStyle: .body)
+    messageLabel.adjustsFontForContentSizeCategory = true
+    messageLabel.numberOfLines = 0
+    messageLabel.textAlignment = .natural
+    messageLabel.textColor = .appLabel
+    messageLabel.translatesAutoresizingMaskIntoConstraints = false
 
-    label.text = message
-    label.font = .preferredFont(forTextStyle: .body)
-    label.adjustsFontForContentSizeCategory = true
-    label.numberOfLines = 0
-    label.textAlignment = .center
-    label.backgroundColor = .appBackground
-    label.textColor = .appLabel
+    view.addSubview(messageLabel)
+
+    let layoutGuide = view.safeAreaLayoutGuide
+
+    let labelConstraints = [
+      messageLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
+      messageLabel.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 16),
+      messageLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
+    ]
+
+    NSLayoutConstraint.activate(labelConstraints)
   }
 
   // MARK: Unavailable

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -199,7 +199,7 @@ func getCheckoutV2Handler() -> CheckoutV2Handler? {
   checkoutV2Handler
 }
 
-/// Set the checkout handler for handling asychronous web view events mostly associated
+/// Set the checkout handler for handling asynchronous web view events mostly associated
 /// with express checkout. The handler is retained weakly and as such a strong reference should be
 /// maintained outside of the SDK.
 /// - Parameter handler: The Checkout Handler.

--- a/Sources/Afterpay/Checkout/CheckoutV2Message.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2Message.swift
@@ -77,7 +77,7 @@ struct CheckoutV2Message: Codable {
     case .shippingOptions(let shippingOptions):
       try container.encode(shippingOptions, forKey: .payload)
     case .errorMessage(let errorMessage):
-      // This is asymmentric with decode, errors are encoded as their own key/value pair when sent
+      // This is asymmetric with decode, errors are encoded as their own key/value pair when sent
       // not as the payload
       try container.encode(errorMessage, forKey: .error)
     default:

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -329,7 +329,7 @@ final class CheckoutV2ViewController:
           postMessage(responseMessage)
         }
       case .errorMessage(let errorMessage):
-        // Error messages raised in the webview are loged when in Debug for ease of debugging
+        // Error messages raised in the webview are logged when in Debug for ease of debugging
         os_log("%@", log: .checkout, type: .debug, errorMessage)
       case .shippingOption(let shippingOption):
         shippingOptionDidChange?(shippingOption)

--- a/Sources/Afterpay/Features.swift
+++ b/Sources/Afterpay/Features.swift
@@ -8,10 +8,12 @@
 
 import Foundation
 
-struct Features {
+public struct AfterpayFeatures {
 
   /// Is the checkout widget enabled?
-  static var widgetEnabled: Bool {
+  ///
+  /// Enable by setting '`-com.afterpay.widget-enabled YES`' argument on launch.
+  public static var widgetEnabled: Bool {
     UserDefaults.standard.bool(forKey: "com.afterpay.widget-enabled")
   }
 

--- a/Sources/Afterpay/Views/LinkTextView.swift
+++ b/Sources/Afterpay/Views/LinkTextView.swift
@@ -26,11 +26,11 @@ final class LinkTextView: UITextView, UITextViewDelegate {
     delegate = self
   }
 
-  // Overide point inside to prevent interation with anything that isn't the link.
+  // Override point inside to prevent interaction with anything that isn't the link.
   // Unfortunately implementing UITextViewDelegate textView(_:shouldInteractWith:in:interaction:)
   // for NSTextAttachments isn't enough to prevent drag and drop being initiated
   override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-    // TODO: Test if this is neccesary when language is set to an RTL language
+    // TODO: Test if this is necessary when language is set to an RTL language
     let isRightToLeft = traitCollection.layoutDirection == .rightToLeft
     let direction: UITextLayoutDirection = isRightToLeft ? .right : .left
 

--- a/Sources/Afterpay/Views/PriceBreakdownView.swift
+++ b/Sources/Afterpay/Views/PriceBreakdownView.swift
@@ -18,7 +18,7 @@ public protocol PriceBreakdownViewDelegate: AnyObject {
 
 }
 
-/// A view that displays informative text, the afterpay badge and an info link. The info link will
+/// A view that displays informative text, the Afterpay badge and an info link. The info link will
 /// launch externally by default but can launch modally in app by implementing
 /// PriceBreakdownViewDelegate. This view updates in response to Afterpay configuration changes
 /// as well as changes to the `totalAmount`.

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -68,6 +68,18 @@ public final class WidgetView: UIView, WKNavigationDelegate {
     NSLayoutConstraint.activate(webViewConstraints)
   }
 
+  public func sendUpdate(amount: String) {
+    guard
+      let currencyCode = getConfiguration()?.currencyCode,
+      let data = try? encoder.encode(Money(amount: amount, currency: currencyCode)),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return
+    }
+
+    webView.evaluateJavaScript(#"update(\#(json))"#)
+  }
+
   // MARK: WKNavigationDelegate
 
   public func webView(

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -1,0 +1,98 @@
+//
+//  WidgetView.swift
+//  Afterpay
+//
+//  Created by Huw Rowlands on 11/3/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import WebKit
+
+public final class WidgetView: UIView, WKNavigationDelegate {
+
+  private var webView: WKWebView!
+  private let token: String
+
+  private let encoder = JSONEncoder()
+  private let decoder = JSONDecoder()
+
+  public init(token: String) {
+    precondition(
+      AfterpayFeatures.widgetEnabled,
+      "`WidgetView` is experimental. Enable by passing launch argument `-com.afterpay.widget-enabled YES`."
+    )
+
+    self.token = token
+
+    super.init(frame: .zero)
+
+    setupWebView()
+    setupConstraints()
+  }
+
+  // MARK: Subviews
+
+  private func setupWebView() {
+    let preferences = WKPreferences()
+    preferences.javaScriptEnabled = true
+    preferences.javaScriptCanOpenWindowsAutomatically = true
+
+    let processPool = WKProcessPool()
+
+    let bootstrapConfiguration = WKWebViewConfiguration()
+    bootstrapConfiguration.processPool = processPool
+    bootstrapConfiguration.preferences = preferences
+
+    webView = WKWebView(frame: .zero, configuration: bootstrapConfiguration)
+    webView.navigationDelegate = self
+    webView.allowsLinkPreview = false
+    webView.scrollView.isScrollEnabled = false
+
+    webView.load(URLRequest(url: URL(string: "http://localhost:8000/widget-bootstrap.html")!))
+
+    addSubview(webView)
+  }
+
+  private func setupConstraints() {
+    webView.translatesAutoresizingMaskIntoConstraints = false
+
+    let webViewConstraints = [
+      webView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      webView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      webView.topAnchor.constraint(equalTo: topAnchor),
+      webView.bottomAnchor.constraint(equalTo: bottomAnchor),
+    ]
+
+    NSLayoutConstraint.activate(webViewConstraints)
+  }
+
+  // MARK: WKNavigationDelegate
+
+  public func webView(
+    _ webView: WKWebView,
+    decidePolicyFor navigationAction: WKNavigationAction,
+    decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+  ) {
+    guard let url = navigationAction.request.url, navigationAction.targetFrame == nil else {
+      return decisionHandler(.allow)
+    }
+
+    decisionHandler(.cancel)
+    UIApplication.shared.open(url)
+  }
+
+  public func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+    let javaScript = #"createAfterpayWidget("\#(self.token)");"#
+    self.webView.evaluateJavaScript(javaScript)
+  }
+
+  // MARK: Unavailable
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+}

--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -1,0 +1,62 @@
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	</head>
+	<body style="margin: 0px -7px">
+		<div id="afterpay-widget-container"></div>
+
+		<script>
+
+			function createAfterpayWidget(token) {
+				window.afterpayWidget = new AfterPay.Widgets.PaymentSchedule({
+					token: token,
+					target: "#afterpay-widget-container",
+					locale: "en-US",
+					onReady: function (event) {
+						sendToApp(event);
+					},
+					onChange: function (event) {
+						sendToApp(event);
+					},
+					onError: function (event) {
+						sendToApp(event);
+					},
+					style: {
+						border: false,
+					}
+				});
+			}
+
+			const app = window.webkit.messageHandlers.iOS;
+			
+			// in error:
+			// {error: Object, isValid: false, amountDueToday: undefined, paymentScheduleChecksum: undefined}
+
+			function sendToApp(event) {
+				const data = event.data;
+				let completeData = {
+					...data,
+					"type": event.type
+				};
+				
+				if (typeof data.amountDueToday !== 'undefined') {
+					completeData.amountDueToday = {
+						"amount": data.amountDueToday.amount,
+						"currency": data.amountDueToday.currency
+					}
+				}
+				
+				app.postMessage(JSON.stringify(completeData));
+			}
+
+			function update(data) {
+				window.afterpayWidget.update({
+					amount: data 
+				});
+			}
+
+			</script>
+
+		<script src="https://portal.sandbox.afterpay.com/afterpay.js?merchant_key=demo"></script>
+	</body>
+</html>


### PR DESCRIPTION
This `WidgetView` does not do much other than host a web view. It’s a web view inside a UIKit view. That’s pretty much all for now, but it will be doing a lot more soon. For now, it will only load the Afterpay widget via the bootstrap page.

## Summary of Changes

- Add `WidgetView`. Make one of these with a checkout token, then plop it on the screen. For now, it will start loading and showing the web widget as soon as it is initialised. 
- You can tell the `WidgetView` that it's amount has been changed. Note: this func takes a String for now. That’s just convenient for turning it into a `Money` value:

```swift
widgetView.sendUpdate(amount: "$23.20")
```

- We are feature toggled with the launch argument:  `-com.afterpay.widget-enabled YES`

## Items of Note

On macOS, you can run the bootstrap page by going to the project root directory and running:

```bash 
    python -m SimpleHTTPServer
```

The `Example` app has been updated to show the Widget on the Messages page after checkout. It is feature toggled with the launch argument: `-com.afterpay.widget-enabled YES`. 

## Submission Checklist

There's not much documentation yet. This will be added as we get more certainty on how the `WidgetView` will behave.
