### PR TITLE
Receive events from Widget

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		551BEDEB25F983E200FDF9EE /* Features.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDEA25F983E200FDF9EE /* Features.swift */; };
 		551BEDF125F98FA800FDF9EE /* FeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */; };
 		551BEDF825F9B95C00FDF9EE /* WidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDF725F9B95C00FDF9EE /* WidgetView.swift */; };
+		551BEDFC25F9C56600FDF9EE /* WidgetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDFB25F9C56600FDF9EE /* WidgetEvent.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
 		6615F99B24D14620005036F1 /* SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6615F99A24D14620005036F1 /* SVG.swift */; };
@@ -72,6 +73,7 @@
 		551BEDEA25F983E200FDF9EE /* Features.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features.swift; sourceTree = "<group>"; };
 		551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesTests.swift; sourceTree = "<group>"; };
 		551BEDF725F9B95C00FDF9EE /* WidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetView.swift; sourceTree = "<group>"; };
+		551BEDFB25F9C56600FDF9EE /* WidgetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEvent.swift; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
 		6615F99A24D14620005036F1 /* SVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SVG.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 		551BEDF625F9B92A00FDF9EE /* Widget */ = {
 			isa = PBXGroup;
 			children = (
+				551BEDFB25F9C56600FDF9EE /* WidgetEvent.swift */,
 				551BEDF725F9B95C00FDF9EE /* WidgetView.swift */,
 			);
 			path = Widget;
@@ -511,6 +514,7 @@
 				6689536C24C96CB5005090B4 /* Configuration.swift in Sources */,
 				15F7DDB725393BD30011EC25 /* CurrencyFormatter.swift in Sources */,
 				66DAAC8B24E0CF0100127460 /* PriceBreakdown.swift in Sources */,
+				551BEDFC25F9C56600FDF9EE /* WidgetEvent.swift in Sources */,
 				661CFDB62570E7F000D8A1E8 /* PaymentButton.swift in Sources */,
 				662A3AED24A999A500EFD826 /* CheckoutResult.swift in Sources */,
 				551BEDF825F9B95C00FDF9EE /* WidgetView.swift in Sources */,

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		157C65AD25D0F19900115149 /* Result+Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157C65AC25D0F19900115149 /* Result+Fold.swift */; };
 		5539D82C25EDE97E0088BC97 /* ControlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5539D82B25EDE97E0088BC97 /* ControlCell.swift */; };
 		5539D83025F068F90088BC97 /* CheckoutOptionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5539D82F25F068F90088BC97 /* CheckoutOptionsCell.swift */; };
+		55FA7270260025DC0006EFCB /* WidgetHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FA726F260025DC0006EFCB /* WidgetHandler.swift */; };
 		660072B724A1B55E00E9A2BC /* TextSettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660072B624A1B55E00E9A2BC /* TextSettingCell.swift */; };
 		6620B5D224934FB3004162BC /* AppFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6620B5D124934FB3004162BC /* AppFlowController.swift */; };
 		663A228E249B030D0027C296 /* MessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663A228D249B030D0027C296 /* MessageViewController.swift */; };
@@ -74,6 +75,7 @@
 		157C65AC25D0F19900115149 /* Result+Fold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+Fold.swift"; sourceTree = "<group>"; };
 		5539D82B25EDE97E0088BC97 /* ControlCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCell.swift; sourceTree = "<group>"; };
 		5539D82F25F068F90088BC97 /* CheckoutOptionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutOptionsCell.swift; sourceTree = "<group>"; };
+		55FA726F260025DC0006EFCB /* WidgetHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetHandler.swift; sourceTree = "<group>"; };
 		660072B624A1B55E00E9A2BC /* TextSettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSettingCell.swift; sourceTree = "<group>"; };
 		6620B5D124934FB3004162BC /* AppFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowController.swift; sourceTree = "<group>"; };
 		663A228D249B030D0027C296 /* MessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageViewController.swift; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 				66E6FDA324AC344800ED81E8 /* PurchaseLogicController.swift */,
 				66E6FDA724AC3BDD00ED81E8 /* PurchaseState.swift */,
 				66BD11B324ADB7EB00039DA6 /* TitleSubtitleCell.swift */,
+				55FA726F260025DC0006EFCB /* WidgetHandler.swift */,
 			);
 			path = Purchase;
 			sourceTree = "<group>";
@@ -401,6 +404,7 @@
 				660072B724A1B55E00E9A2BC /* TextSettingCell.swift in Sources */,
 				668F162424877F950040345C /* SceneDelegate.swift in Sources */,
 				155AD17124AB2464000013B4 /* PurchaseFlowController.swift in Sources */,
+				55FA7270260025DC0006EFCB /* WidgetHandler.swift in Sources */,
 				6662628A2496F5EB0094FC26 /* APIClient.swift in Sources */,
 				665E6A0B24935624009E3BA1 /* Extensions.swift in Sources */,
 				945B92A624DA19FA0009BD3C /* Environment.swift in Sources */,

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -15,6 +15,7 @@ final class PurchaseFlowController: UIViewController {
   private let productsViewController: ProductsViewController
   private let ownedNavigationController: UINavigationController
   private let checkoutHandler: CheckoutHandler
+  private let widgetHandler: WidgetHandler
 
   init(logicController purchaseLogicController: PurchaseLogicController) {
     logicController = purchaseLogicController
@@ -40,6 +41,9 @@ final class PurchaseFlowController: UIViewController {
     )
 
     Afterpay.setCheckoutV2Handler(checkoutHandler)
+
+    widgetHandler = WidgetEventHandler()
+    Afterpay.setWidgetHandler(widgetHandler)
 
     super.init(nibName: nil, bundle: nil)
   }

--- a/Example/Example/Purchase/WidgetHandler.swift
+++ b/Example/Example/Purchase/WidgetHandler.swift
@@ -22,4 +22,8 @@ final class WidgetEventHandler: WidgetHandler {
     print("on error")
   }
 
+  func onFailure(error: Error) {
+    print("Internal error occurred in the SDK: \(error.localizedDescription)")
+  }
+
 }

--- a/Example/Example/Purchase/WidgetHandler.swift
+++ b/Example/Example/Purchase/WidgetHandler.swift
@@ -1,0 +1,25 @@
+//
+//  WidgetHandler.swift
+//  Example
+//
+//  Created by Huw Rowlands on 16/3/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import Afterpay
+
+final class WidgetEventHandler: WidgetHandler {
+
+  func onReady(isValid: Bool, amountDueToday: Money, paymentScheduleChecksum: String) {
+    print("on ready")
+  }
+
+  func onChanged(status: WidgetStatus) {
+    print("on changed")
+  }
+
+  func onError(errorCode: String, message: String) {
+    print("on error")
+  }
+
+}

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -207,9 +207,9 @@ public func setCheckoutV2Handler(_ handler: CheckoutV2Handler?) {
   checkoutV2Handler = handler
 }
 
-/// A handler of web view events for the widget.
+/// A handler of web view events from the widget.
 ///
-/// Conforming to this protocol and calling `Afterpay.setWidgetHandler` will enable the display of the `WidgetView`.
+/// An object which conforms to the protocol and sent to `Afterpay.setWidgetHandler` will receive the web view events from the widget. It will allow
 public protocol WidgetHandler: AnyObject {
 
   /// Fires when the widget is ready to accept updates.
@@ -218,9 +218,19 @@ public protocol WidgetHandler: AnyObject {
   /// Fires after each update and on any other state changes.
   ///
   /// Check the status to know if the Widget is currently valid or invalid.
+  ///
+  /// If valid, use the associated values in the `status` to update your checkout UI.
+  ///
+  /// If it's invalid, the widget itself will inform the user something has gone wrong, but the values associated with `WidgetStatus.invalid` will provide some information, too. In this instance, the `onError` callback will also be called.
+  ///
+  /// - Parameter status: A `WidgetStatus`, which is either `valid` or `invalid` and contains associated values for either situation
   func onChanged(status: WidgetStatus)
 
-  /// Fires when a state change causes an error. This event is in addition an invalid status being sent to `onChanged`.
+  /// Fires when a state change causes an error.
+  ///
+  /// When this happens, the widget is not valid, and the checkout should not proceed. The widget will inform the user of errors on its own, but some error information is also sent through here for convenience.
+  ///
+  /// This callback is in addition to an `invalid` status being sent to `onChanged`.
   func onError(errorCode: String, message: String)
 
 }
@@ -234,7 +244,7 @@ func getWidgetHandler() -> WidgetHandler? {
 /// Set the checkout handler for handling asynchronous events from the `WidgetView`.
 ///
 /// The handler is retained weakly and as such a strong reference should be maintained outside of the SDK.
-/// - Parameter handler: The Checkout Handler.
+/// - Parameter handler: A `WidgetHandler`
 public func setWidgetHandler(_ handler: WidgetHandler?) {
   widgetHandler = handler
 }

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -209,7 +209,8 @@ public func setCheckoutV2Handler(_ handler: CheckoutV2Handler?) {
 
 /// A handler of web view events from the widget.
 ///
-/// An object which conforms to the protocol and sent to `Afterpay.setWidgetHandler` will receive the web view events from the widget. It will allow
+/// An object which conforms to the protocol and sent to `Afterpay.setWidgetHandler` will receive the web view events
+/// from the widget.
 public protocol WidgetHandler: AnyObject {
 
   /// Fires when the widget is ready to accept updates.
@@ -221,14 +222,18 @@ public protocol WidgetHandler: AnyObject {
   ///
   /// If valid, use the associated values in the `status` to update your checkout UI.
   ///
-  /// If it's invalid, the widget itself will inform the user something has gone wrong, but the values associated with `WidgetStatus.invalid` will provide some information, too. In this instance, the `onError` callback will also be called.
+  /// If it's invalid, the widget itself will inform the user something has gone wrong, but the values associated with
+  /// `WidgetStatus.invalid` will provide some information, too. In this instance, the `onError` callback will also be
+  /// called.
   ///
-  /// - Parameter status: A `WidgetStatus`, which is either `valid` or `invalid` and contains associated values for either situation
+  /// - Parameter status: A `WidgetStatus`, which is either `valid` or `invalid` and contains associated values for
+  /// either situation
   func onChanged(status: WidgetStatus)
 
   /// Fires when a state change causes an error.
   ///
-  /// When this happens, the widget is not valid, and the checkout should not proceed. The widget will inform the user of errors on its own, but some error information is also sent through here for convenience.
+  /// When this happens, the widget is not valid, and the checkout should not proceed. The widget will inform the user
+  /// of errors on its own, but some error information is also sent through here for convenience.
   ///
   /// This callback is in addition to an `invalid` status being sent to `onChanged`.
   func onError(errorCode: String, message: String)

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -233,6 +233,9 @@ public protocol WidgetHandler: AnyObject {
   /// This callback is in addition to an `invalid` status being sent to `onChanged`.
   func onError(errorCode: String, message: String)
 
+  /// Fires when an internal error happens inside the SDK.
+  func onFailure(error: Error)
+
 }
 
 private weak var widgetHandler: WidgetHandler?

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -207,6 +207,38 @@ public func setCheckoutV2Handler(_ handler: CheckoutV2Handler?) {
   checkoutV2Handler = handler
 }
 
+/// A handler of web view events for the widget.
+///
+/// Conforming to this protocol and calling `Afterpay.setWidgetHandler` will enable the display of the `WidgetView`.
+public protocol WidgetHandler: AnyObject {
+
+  /// Fires when the widget is ready to accept updates.
+  func onReady(isValid: Bool, amountDueToday: Money, paymentScheduleChecksum: String)
+
+  /// Fires after each update and on any other state changes.
+  ///
+  /// Check the status to know if the Widget is currently valid or invalid.
+  func onChanged(status: WidgetStatus)
+
+  /// Fires when a state change causes an error. This event is in addition an invalid status being sent to `onChanged`.
+  func onError(errorCode: String, message: String)
+
+}
+
+private weak var widgetHandler: WidgetHandler?
+
+func getWidgetHandler() -> WidgetHandler? {
+  widgetHandler
+}
+
+/// Set the checkout handler for handling asynchronous events from the `WidgetView`.
+///
+/// The handler is retained weakly and as such a strong reference should be maintained outside of the SDK.
+/// - Parameter handler: The Checkout Handler.
+public func setWidgetHandler(_ handler: WidgetHandler?) {
+  widgetHandler = handler
+}
+
 // MARK: - Authentication
 
 /// A handler that is passed a `challenge` a `completionHandler`. If the challenge has been

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -1,0 +1,74 @@
+//
+//  WidgetEvent.swift
+//  Afterpay
+//
+//  Created by Huw Rowlands on 11/3/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+public enum WidgetStatus {
+
+  case valid(amountDue: Money, checksum: String)
+  case invalid(errorCode: String, message: String)
+
+}
+
+enum WidgetEvent: Decodable {
+
+  case ready(isValid: Bool, amountDue: Money, checksum: String)
+  case change(status: WidgetStatus)
+  case error(errorCode: String, message: String)
+
+  private enum CodingKeys: String, CodingKey {
+    case type, isValid, amountDueToday, paymentScheduleChecksum, error
+  }
+
+  private enum EventType: String, Decodable {
+    case ready, change, error
+  }
+
+  private struct WidgetError: Codable {
+    let errorCode: String
+    let message: String
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    let type = try container.decode(EventType.self, forKey: .type)
+
+    switch type {
+    case .error:
+      let error = try container.decode(WidgetError.self, forKey: .error)
+      self = .error(errorCode: error.errorCode, message: error.message)
+
+    case .ready:
+      let isValid = try container.decode(Bool.self, forKey: .isValid)
+      let amountDue = try container.decode(Money.self, forKey: .amountDueToday)
+      let checksum = try container.decode(String.self, forKey: .paymentScheduleChecksum)
+
+      self = .ready(isValid: isValid, amountDue: amountDue, checksum: checksum)
+
+    case .change:
+      let valid = try container.decode(Bool.self, forKey: .isValid)
+
+      let status: WidgetStatus
+
+      if valid {
+        let amountDue = try container.decode(Money.self, forKey: .amountDueToday)
+        let checksum = try container.decode(String.self, forKey: .paymentScheduleChecksum)
+
+        status = .valid(amountDue: amountDue, checksum: checksum)
+      } else {
+        let error = try container.decode(WidgetError.self, forKey: .error)
+
+        status = .invalid(errorCode: error.errorCode, message: error.message)
+      }
+
+      self = .change(status: status)
+    }
+  }
+
+}

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -10,7 +10,10 @@ import Foundation
 
 public enum WidgetStatus {
 
+  /// The widget is valid. In particular, this provides the total amount due, and the payment schedule checksum, which should be persisted on the merchant backend.
   case valid(amountDue: Money, checksum: String)
+
+  /// The widget is invalid, and checkout should not proceed. Although the widget will inform the user of the errors on its own, they are also provided here for convenience.
   case invalid(errorCode: String, message: String)
 
 }

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -22,7 +22,6 @@ public enum WidgetStatus {
   /// if they are available.
   case invalid(errorCode: String?, message: String?)
 
-
 }
 
 enum WidgetEvent: Decodable {

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -10,13 +10,18 @@ import Foundation
 
 public enum WidgetStatus {
 
-  /// The widget is valid. In particular, this provides the total amount due, and the payment schedule checksum, which
-  /// should be persisted on the merchant backend.
+  /// The widget is valid.
+  ///
+  /// In particular, this provides the total amount due, and the payment schedule checksum; both of which should be
+  /// persisted on the merchant backend.
   case valid(amountDue: Money, checksum: String)
 
-  /// The widget is invalid, and checkout should not proceed. Although the widget will inform the user of the errors on
-  /// its own, they are also provided here for convenience.
-  case invalid(errorCode: String, message: String)
+  /// The widget is invalid, and checkout should not proceed
+  ///
+  /// Although the widget will inform the user of the errors on its own, they are also provided here for convenience
+  /// if they are available.
+  case invalid(errorCode: String?, message: String?)
+
 
 }
 

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -10,10 +10,12 @@ import Foundation
 
 public enum WidgetStatus {
 
-  /// The widget is valid. In particular, this provides the total amount due, and the payment schedule checksum, which should be persisted on the merchant backend.
+  /// The widget is valid. In particular, this provides the total amount due, and the payment schedule checksum, which
+  /// should be persisted on the merchant backend.
   case valid(amountDue: Money, checksum: String)
 
-  /// The widget is invalid, and checkout should not proceed. Although the widget will inform the user of the errors on its own, they are also provided here for convenience.
+  /// The widget is invalid, and checkout should not proceed. Although the widget will inform the user of the errors on
+  /// its own, they are also provided here for convenience.
   case invalid(errorCode: String, message: String)
 
 }

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -52,7 +52,12 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     webView.allowsLinkPreview = false
     webView.scrollView.isScrollEnabled = false
 
-    webView.load(URLRequest(url: URL(string: "http://localhost:8000/widget-bootstrap.html")!))
+    webView.load(
+      URLRequest(
+        url: URL(string: "http://localhost:8000/widget-bootstrap.html")!,
+        cachePolicy: .reloadIgnoringLocalCacheData
+      )
+    )
 
     addSubview(webView)
   }

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -83,9 +83,11 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
 
   /// Inform the widget about a change to the order total.
   ///
-  /// Any time the order total changes (for example, a change of shipping option, promo code, or cart contents), the widget must be notified of the new amount.
+  /// Any time the order total changes (for example, a change of shipping option, promo code, or cart contents),
+  /// the widget must be notified of the new amount.
   ///
-  /// - Parameter amount: The order total as a String. Must be in the same currency that was sent to `Afterpay.setConfiguration`.
+  /// - Parameter amount: The order total as a String. Must be in the same currency that was sent to
+  /// `Afterpay.setConfiguration`.
   public func sendUpdate(amount: String) {
     guard
       let currencyCode = getConfiguration()?.currencyCode,

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -81,6 +81,11 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     NSLayoutConstraint.activate(webViewConstraints)
   }
 
+  /// Inform the widget about a change to the order total.
+  ///
+  /// Any time the order total changes (for example, a change of shipping option, promo code, or cart contents), the widget must be notified of the new amount.
+  ///
+  /// - Parameter amount: The order total as a String. Must be in the same currency that was sent to `Afterpay.setConfiguration`.
   public func sendUpdate(amount: String) {
     guard
       let currencyCode = getConfiguration()?.currencyCode,

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -119,14 +119,15 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     _ userContentController: WKUserContentController,
     didReceive message: WKScriptMessage
   ) {
-    guard
-      let jsonData = (message.body as? String)?.data(using: .utf8),
-      let widgetEvent = try? decoder.decode(WidgetEvent.self, from: jsonData)
-    else {
-      return
-    }
+    let jsonData = (message.body as? String)?.data(using: .utf8)
 
-    getWidgetHandler()?.didReceiveEvent(widgetEvent)
+    do {
+      let widgetEvent = try decoder.decode(WidgetEvent.self, from: jsonData ?? Data())
+      getWidgetHandler()?.didReceiveEvent(widgetEvent)
+
+    } catch {
+      getWidgetHandler()?.onFailure(error: error)
+    }
   }
 
   // MARK: Unavailable


### PR DESCRIPTION
Previously, we would set up the web widget, and that would be that. Now, when we provide Afterpay with an object that conforms to the `WidgetHandler` protocol, that will be sent all the events from the web widget.

We have made our `WidgetView` into a `WKScriptMessageHandler`. It sets itself as a handler for a user content controller. It receives events from the web widget via the `userContentController(_:didReceive:)` callback method. This is similar to how the `CheckoutV2ViewController` receives events from its bootstrap. 

All widget events go through the `userContentController(_:didReceive:)` method. In there, it decodes them as `WidgetEvent`. Then, depending on the kind of event (`ready`, `error` or `changed`), it calls the appropriate `WidgetHandler` method.

The `WidgetHandler` methods directly map to an equivalent on the web widget. It doesn’t have to be that way, but this is the case for now.

The `WidgetEvent` enum models all the different kind of events that can happen to the web widget.

## Summary of Changes

- `WidgetView` is now a `WKScriptMessageHandler`. It uses this to get passed events from the web widget. There is also some code in the bootstrap to support a neat bridging of JavaScript objects to Swift-land
- Add `WidgetHandler` protocol
  - `onReady` - called when the widget is ready
  - `onError` - called when the widget is sad and has had an error
  - `onChanged` - called when the widget has had a change. This is passed a `WidgetStatus` value; this is an enum which can be `valid` or `invalid`, and has associated values for more information (see the `WidgetStatus` inline docs).
- There's also a `onFailure` method on the `WidgetHandler` protocol. This one is called if there has been a kind of failure in the translation of a web widget event (for example, if the JSON data could not be decoded).

## Items of Note

I dithered about adding an `onFailure` event, but ended up deciding that it was a good idea. 

We do not want the web widget and the merchant app checkout screen to get out of sync. A change may happen in the web widget, and it may not get propagated to the merchant app if there is some kind of breakdown in the contract between the SDK and the web widget. In that situation, we need to let the merchant app know something's not right. If we don't, the web widget may be displaying something that is in conflict with the merchant app.

## Submission Checklist

- [x] Documentation is changed or added.
