### PR TITLE
Add method to get the widget's status

### DIFF
--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -15,6 +15,8 @@ final class MessageViewController: UIViewController {
   private var widgetView: WidgetView!
   private let updateButton = UIButton(type: .system)
 
+  private let getStatusButton = UIButton(type: .system)
+
   private let message: String
   private let token: Token
 
@@ -32,6 +34,7 @@ final class MessageViewController: UIViewController {
     setupMessageLabel()
     setupWidget()
     setupWidgetUpdateButton()
+    setupGetStatusButton()
   }
 
   private func setupMessageLabel() {
@@ -97,12 +100,47 @@ final class MessageViewController: UIViewController {
     NSLayoutConstraint.activate(constraints)
   }
 
+  private func setupGetStatusButton() {
+    guard AfterpayFeatures.widgetEnabled else { return }
+
+    getStatusButton.setTitle("Print status to console", for: .normal)
+    getStatusButton.translatesAutoresizingMaskIntoConstraints = false
+    getStatusButton.addTarget(self, action: #selector(getStatusTapped), for: .touchUpInside)
+    getStatusButton.translatesAutoresizingMaskIntoConstraints = false
+
+    view.addSubview(getStatusButton)
+
+    let layoutGuide = view.safeAreaLayoutGuide
+
+    let constraints = [
+      getStatusButton.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
+      getStatusButton.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
+      getStatusButton.topAnchor.constraint(equalTo: updateButton.bottomAnchor, constant: 16),
+    ]
+
+    NSLayoutConstraint.activate(constraints)
+  }
+
   @objc private func updateTapped() {
     let randomDouble = Double.random(in: 0..<99)
 
     widgetView.sendUpdate(
       amount: String(format: "%.2f", randomDouble)
     )
+  }
+
+  @objc private func getStatusTapped() {
+    DispatchQueue.main.async { [widgetView] in
+      widgetView?.getStatus { result in
+        switch result {
+        case .failure(let error):
+          print("Sorry: \(error.localizedDescription)")
+        case .success(let status):
+          print("Status: \(status)")
+        }
+      }
+    }
+
   }
 
   // MARK: Unavailable

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum WidgetStatus {
+public enum WidgetStatus: Decodable {
 
   /// The widget is valid.
   ///
@@ -21,6 +21,23 @@ public enum WidgetStatus {
   /// Although the widget will inform the user of the errors on its own, they are also provided here for convenience
   /// if they are available.
   case invalid(errorCode: String?, message: String?)
+
+  private enum CodingKeys: String, CodingKey {
+    case isValid, amountDueToday, paymentScheduleChecksum
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    if try container.decode(Bool.self, forKey: .isValid) == true {
+      let amountDue = try container.decode(Money.self, forKey: .amountDueToday)
+      let checksum = try container.decode(String.self, forKey: .paymentScheduleChecksum)
+
+      self = .valid(amountDue: amountDue, checksum: checksum)
+    } else {
+      self = .invalid(errorCode: nil, message: nil)
+    }
+  }
 
 }
 

--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -29,9 +29,6 @@
 
 			const app = window.webkit.messageHandlers.iOS;
 			
-			// in error:
-			// {error: Object, isValid: false, amountDueToday: undefined, paymentScheduleChecksum: undefined}
-
 			function sendToApp(event) {
 				const data = event.data;
 				let completeData = {
@@ -53,6 +50,28 @@
 				window.afterpayWidget.update({
 					amount: data 
 				});
+			}
+			
+			/// Returns the complete status update of the widget.
+			/// 
+			/// Rather than the SDK having to ask about each property individually in turn, this collects it into one.
+			function getWidgetStatus() {
+				const widget = window.afterpayWidget;
+				
+				let data = {
+					"isValid": widget.isValid,
+					"paymentScheduleChecksum": widget.paymentScheduleChecksum,
+					"error": widget.error
+				}
+				
+				if (typeof widget.amountDueToday !== 'undefined') {
+					data.amountDueToday = {
+						"amount": widget.amountDueToday.amount,
+						"currency": widget.amountDueToday.currency
+					}
+				}
+				
+				return JSON.stringify(data);
 			}
 
 			</script>


### PR DESCRIPTION
Previously, we only had the `WidgetHandler` call-backs, which would be called when the web widget changed status. This method can be called by the merchant app can call this method any time, and receive the current status in the method's callback.

There are several JavaScript properties on the web widget which can be used to ask about the widget's status. Rather than calling them one by one, decoding, and sending back the value in a call-back, we want to merge them together in one status value. Fortunately, we already have a structure which fits this bill: the `WidgetStatus`.

The bootstrap pages' JavaScript is responsible for merging the web widget's JavaScript properties together into one object. The object which it returns is decodable into a `WidgetStatus`.

## Summary of Changes

- Add function in bootstrap JavaScript to merge the web widget's status together into one object
- Conform `WidgetStatus` to `Decodable` so it can be made from that object
- Add method to `WidgetView` which calls the JavaScript function, and gives you the `WidgetStatus` in a callback. This callback is on the main thread.
