### PR TITLE
Huwr/update widget

### DIFF
--- a/Example/Example/Purchase/WidgetHandler.swift
+++ b/Example/Example/Purchase/WidgetHandler.swift
@@ -11,11 +11,11 @@ import Afterpay
 final class WidgetEventHandler: WidgetHandler {
 
   func onReady(isValid: Bool, amountDueToday: Money, paymentScheduleChecksum: String) {
-    print("on ready")
+    print("On ready: valid: \(isValid), amount due: \(amountDueToday), checksum: \(paymentScheduleChecksum)")
   }
 
   func onChanged(status: WidgetStatus) {
-    print("on changed")
+    print("On changed: new status: \(status)")
   }
 
   func onError(errorCode: String?, message: String?) {

--- a/Example/Example/Purchase/WidgetHandler.swift
+++ b/Example/Example/Purchase/WidgetHandler.swift
@@ -18,8 +18,8 @@ final class WidgetEventHandler: WidgetHandler {
     print("on changed")
   }
 
-  func onError(errorCode: String, message: String) {
-    print("on error")
+  func onError(errorCode: String?, message: String?) {
+    print("On error: code \(errorCode ?? "null"), message: \(message ?? "null")")
   }
 
   func onFailure(error: Error) {

--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -25,6 +25,8 @@ final class MessageViewController: UIViewController {
     self.token = token
 
     super.init(nibName: nil, bundle: nil)
+
+    self.title = message
   }
 
   override func loadView() {
@@ -38,6 +40,8 @@ final class MessageViewController: UIViewController {
   }
 
   private func setupMessageLabel() {
+    guard AfterpayFeatures.widgetEnabled == false else { return }
+
     messageLabel.text = message
     messageLabel.font = .preferredFont(forTextStyle: .body)
     messageLabel.adjustsFontForContentSizeCategory = true
@@ -70,7 +74,7 @@ final class MessageViewController: UIViewController {
     let layoutGuide = view.safeAreaLayoutGuide
 
     let constraints = [
-      widgetView.topAnchor.constraint(equalTo: messageLabel.topAnchor, constant: 32),
+      widgetView.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 16),
       widgetView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
       widgetView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
       widgetView.heightAnchor.constraint(equalToConstant: 350),

--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -13,6 +13,9 @@ final class MessageViewController: UIViewController {
 
   private var messageLabel = UILabel()
   private var widgetView: WidgetView!
+
+  private let updateLabel = UILabel()
+  private let updateField = UITextField()
   private let updateButton = UIButton(type: .system)
 
   private let getStatusButton = UIButton(type: .system)
@@ -35,7 +38,7 @@ final class MessageViewController: UIViewController {
 
     setupMessageLabel()
     setupWidget()
-    setupWidgetUpdateButton()
+    setupWidgetUpdateField()
     setupGetStatusButton()
   }
 
@@ -77,28 +80,39 @@ final class MessageViewController: UIViewController {
       widgetView.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 16),
       widgetView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
       widgetView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
-      widgetView.heightAnchor.constraint(equalToConstant: 350),
+      widgetView.heightAnchor.constraint(equalToConstant: 300),
     ]
 
     NSLayoutConstraint.activate(constraints)
   }
 
-  private func setupWidgetUpdateButton() {
+  private func setupWidgetUpdateField() {
     guard AfterpayFeatures.widgetEnabled else { return }
 
-    updateButton.setTitle("Update widget", for: .normal)
+    updateLabel.text = "Total Amount:"
+    updateLabel.setContentHuggingPriority(UILayoutPriority(rawValue: 249), for: .horizontal)
+
+    updateField.placeholder = "0.00"
+    updateField.keyboardType = .decimalPad
+
+    updateButton.setTitle("Send Update", for: .normal)
     updateButton.translatesAutoresizingMaskIntoConstraints = false
     updateButton.addTarget(self, action: #selector(updateTapped), for: .touchUpInside)
-    updateButton.translatesAutoresizingMaskIntoConstraints = false
+    updateButton.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 751), for: .horizontal)
 
-    view.addSubview(updateButton)
+    let stack = UIStackView(arrangedSubviews: [updateLabel, updateField, updateButton])
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    stack.axis = .horizontal
+    stack.spacing = 8
+
+    view.addSubview(stack)
 
     let layoutGuide = view.safeAreaLayoutGuide
 
     let constraints = [
-      updateButton.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
-      updateButton.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
-      updateButton.topAnchor.constraint(equalTo: widgetView.bottomAnchor, constant: 16),
+      stack.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
+      stack.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
+      stack.topAnchor.constraint(equalTo: widgetView.bottomAnchor, constant: 16),
     ]
 
     NSLayoutConstraint.activate(constraints)
@@ -126,10 +140,8 @@ final class MessageViewController: UIViewController {
   }
 
   @objc private func updateTapped() {
-    let randomDouble = Double.random(in: 0..<99)
-
     widgetView.sendUpdate(
-      amount: String(format: "%.2f", randomDouble)
+      amount: updateField.text ?? ""
     )
   }
 

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -233,10 +233,10 @@ public protocol WidgetHandler: AnyObject {
   /// Fires when a state change causes an error.
   ///
   /// When this happens, the widget is not valid, and the checkout should not proceed. The widget will inform the user
-  /// of errors on its own, but some error information is also sent through here for convenience.
+  /// of errors on its own, but some error information is also sent through here for convenience, if it is available.
   ///
   /// This callback is in addition to an `invalid` status being sent to `onChanged`.
-  func onError(errorCode: String, message: String)
+  func onError(errorCode: String?, message: String?)
 
   /// Fires when an internal error happens inside the SDK.
   func onFailure(error: Error)

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -45,7 +45,7 @@ enum WidgetEvent: Decodable {
 
   case ready(isValid: Bool, amountDue: Money, checksum: String)
   case change(status: WidgetStatus)
-  case error(errorCode: String, message: String)
+  case error(errorCode: String?, message: String?)
 
   private enum CodingKeys: String, CodingKey {
     case type, isValid, amountDueToday, paymentScheduleChecksum, error
@@ -67,8 +67,8 @@ enum WidgetEvent: Decodable {
 
     switch type {
     case .error:
-      let error = try container.decode(WidgetError.self, forKey: .error)
-      self = .error(errorCode: error.errorCode, message: error.message)
+      let error = try? container.decodeIfPresent(WidgetError.self, forKey: .error)
+      self = .error(errorCode: error?.errorCode, message: error?.message)
 
     case .ready:
       let isValid = try container.decode(Bool.self, forKey: .isValid)
@@ -88,9 +88,9 @@ enum WidgetEvent: Decodable {
 
         status = .valid(amountDue: amountDue, checksum: checksum)
       } else {
-        let error = try container.decode(WidgetError.self, forKey: .error)
+        let error = try? container.decodeIfPresent(WidgetError.self, forKey: .error)
 
-        status = .invalid(errorCode: error.errorCode, message: error.message)
+        status = .invalid(errorCode: error?.errorCode, message: error?.message)
       }
 
       self = .change(status: status)

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -120,7 +120,7 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     webView.evaluateJavaScript(#"getWidgetStatus()"#) { [decoder] returnValue, error in
       guard
         let jsonData = (returnValue as? String)?.data(using: .utf8),
-        error != nil
+        error == nil
       else {
         completion(.failure(WidgetError.javaScriptError(source: error)))
         return


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/790199/111562704-c27cfc00-87ea-11eb-97ba-13016d673d3d.png" width="350">

## Summary of Changes

- Message screen elides message when widget enabled
- Add text field to send custom amounts to widget. Previously, we just sent random amounts. Now, the the tester can change it and send a new amount into the widget.
- Fix error check in getting status. We should have been checking that the error is nil, not that it is not nil… 🤦 
- Make error code and messages optional. They may not be being sent from the web sdk. We need to make sure we handle it if they are not being sent. This means we need to make them optional in a number of places.
- Print more from the example handler. Previously, the example widget handler only printed that it had received events. Now, it prints the information it has received in the events. This is handy for testers.

## Items of Note

There are two known problems: 
- The message screen does not scroll. If the content is too big, and goes under the keyboard, that stuff is inaccessible.
- The web view has a hard coded size of 300. If it's too big to fit, then some of the content will be cut off. This will be addressed in a coming PR.

## Submission Checklist

- [x] Documentation is changed or added.
