### PR TITLE
Get WidgetView’s intrinsic size from web view

### DIFF
--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -80,7 +80,6 @@ final class MessageViewController: UIViewController {
       widgetView.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 16),
       widgetView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 16),
       widgetView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -16),
-      widgetView.heightAnchor.constraint(equalToConstant: 300),
     ]
 
     NSLayoutConstraint.activate(constraints)

--- a/Sources/Afterpay/Model/ShippingOption.swift
+++ b/Sources/Afterpay/Model/ShippingOption.swift
@@ -35,7 +35,7 @@ public struct ShippingOption: Codable {
 
 }
 
-public struct Money: Codable {
+public struct Money: Codable, Equatable {
 
   var amount: String
   var currency: String

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -12,9 +12,9 @@ public enum WidgetStatus: Decodable {
 
   /// The widget is valid.
   ///
-  /// In particular, this provides the total amount due, and the payment schedule checksum; both of which should be
+  /// In particular, this provides the amount due today, and the payment schedule checksum; both of which should be
   /// persisted on the merchant backend.
-  case valid(amountDue: Money, checksum: String)
+  case valid(amountDueToday: Money, checksum: String)
 
   /// The widget is invalid, and checkout should not proceed
   ///
@@ -33,7 +33,7 @@ public enum WidgetStatus: Decodable {
       let amountDue = try container.decode(Money.self, forKey: .amountDueToday)
       let checksum = try container.decode(String.self, forKey: .paymentScheduleChecksum)
 
-      self = .valid(amountDue: amountDue, checksum: checksum)
+      self = .valid(amountDueToday: amountDue, checksum: checksum)
     } else {
       self = .invalid(errorCode: nil, message: nil)
     }
@@ -86,7 +86,7 @@ enum WidgetEvent: Decodable {
         let amountDue = try container.decode(Money.self, forKey: .amountDueToday)
         let checksum = try container.decode(String.self, forKey: .paymentScheduleChecksum)
 
-        status = .valid(amountDue: amountDue, checksum: checksum)
+        status = .valid(amountDueToday: amountDue, checksum: checksum)
       } else {
         let error = try? container.decodeIfPresent(WidgetError.self, forKey: .error)
 

--- a/Sources/Afterpay/Widget/WidgetEvent.swift
+++ b/Sources/Afterpay/Widget/WidgetEvent.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum WidgetStatus: Decodable {
+public enum WidgetStatus: Decodable, Equatable {
 
   /// The widget is valid.
   ///
@@ -41,18 +41,19 @@ public enum WidgetStatus: Decodable {
 
 }
 
-enum WidgetEvent: Decodable {
+enum WidgetEvent: Decodable, Equatable {
 
   case ready(isValid: Bool, amountDue: Money, checksum: String)
   case change(status: WidgetStatus)
   case error(errorCode: String?, message: String?)
+  case resize
 
   private enum CodingKeys: String, CodingKey {
     case type, isValid, amountDueToday, paymentScheduleChecksum, error
   }
 
   private enum EventType: String, Decodable {
-    case ready, change, error
+    case ready, change, error, resize
   }
 
   private struct WidgetError: Codable {
@@ -94,6 +95,8 @@ enum WidgetEvent: Decodable {
       }
 
       self = .change(status: status)
+    case .resize:
+      self = .resize
     }
   }
 

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -153,8 +153,8 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
   }
 
   public func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-    let javaScript = #"createAfterpayWidget("\#(self.token)");"#
-    self.webView.evaluateJavaScript(javaScript)
+    let javaScript = #"createAfterpayWidget("\#(token)");"#
+    webView.evaluateJavaScript(javaScript)
   }
 
   // MARK: WKScriptMessageHandler

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -74,6 +74,10 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     }
   }
 
+  public override var intrinsicContentSize: CGSize {
+    webView.scrollView.contentSize
+  }
+
   private func setupConstraints() {
     webView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -169,6 +173,10 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
       let widgetEvent = try decoder.decode(WidgetEvent.self, from: jsonData ?? Data())
       getWidgetHandler()?.didReceiveEvent(widgetEvent)
 
+      if widgetEvent == .resize {
+        invalidateIntrinsicContentSize()
+      }
+
     } catch {
       getWidgetHandler()?.onFailure(error: error)
     }
@@ -196,6 +204,10 @@ private extension WidgetHandler {
 
     case let .ready(isValid, amountDue, checksum):
       onReady(isValid: isValid, amountDueToday: amountDue, paymentScheduleChecksum: checksum)
+
+    case .resize:
+      // Do not need to tell anyone about a resize event. It's handled internally.
+      break
     }
 
   }

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -69,6 +69,7 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
 
   public override func willMove(toSuperview newSuperview: UIView?) {
     if newSuperview == nil {
+      // Remove the handler when being dismissed, so it doesn't keep a strong reference and cause a leak
       webView.configuration.userContentController.removeScriptMessageHandler(forName: "iOS")
     }
   }

--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -6,8 +6,18 @@
 		<div id="afterpay-widget-container"></div>
 
 		<script>
+			const app = window.webkit.messageHandlers.iOS;
 
 			function createAfterpayWidget(token) {
+				
+				new MutationObserver(() => { 
+						app.postMessage(JSON.stringify({ "type": "resize" }))
+					})
+					.observe(
+						document.getElementById('afterpay-widget-container'),
+						{ attributes: true, childList: true, subtree: true }
+					);
+				
 				window.afterpayWidget = new AfterPay.Widgets.PaymentSchedule({
 					token: token,
 					target: "#afterpay-widget-container",
@@ -27,8 +37,6 @@
 				});
 			}
 
-			const app = window.webkit.messageHandlers.iOS;
-			
 			function sendToApp(event) {
 				const data = event.data;
 				let completeData = {


### PR DESCRIPTION
Previously, we had to constrain the `WidgetView` to a fixed height. Now, it has an intrinsic content size which comes from the web view. That means the web view controls how big to make the `WidgetView`.

The web view does occasionally need to signal to us that it needs to change size, such as after loading. We’ve introduced a new `WidgetEvent` for this: `resize`. We use a MutationObserver in the bootstrap to send the resize via postMessage. On the iOS side, we handle a resize by calling `invalidateIntrinsicContentSize`. We don’t need to inform the `WidgetHandler` about a resize.

Since we made `WidgetEvent` conform to `Equatable`, we also had to make the `WidgetStatus` and `Money` types `Equatable` as well.

## Summary of Changes

- `WidgetView` gets its intrinsic content size from the web view's scroll view
- Introduce `resize` event, emitted via postMessage whenever something changes with the `#afterpay-widget-container` div.
- `WidgetView` responds to `resize` by invalidating its intrinsic content size

## Items of Note

This could be a little better. It can be a bit janky, but it's a lot better than manually sizing.
