### PR TITLE
Send style options to the web widget

### DIFF
--- a/Example/Example/Shared/MessageViewController.swift
+++ b/Example/Example/Shared/MessageViewController.swift
@@ -77,7 +77,7 @@ final class MessageViewController: UIViewController {
       widgetView = WidgetView(token: token)
     } else {
       // swiftlint:disable:next force_try
-      widgetView = try! WidgetView(amount: "200.00")
+      widgetView = try! WidgetView(amount: "200.00", style: WidgetView.Style(logo: false, heading: true))
     }
     widgetView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ WidgetView.init(amount:)
 
 ### Widget Options
 
-The widget has appearance options. You will provide these when you initialise the `WidgetView`. 
+The widget has appearance options. You can provide these when you initialise the `WidgetView`. 
 
 Both initialisers take an optional second parameter: a `WidgetView.Style`. The style type contains the appearance options for the widget. At the moment, the only options for `Style` are booleans for the `logo` and the `header`. By default, they are `true`.
 
@@ -578,7 +578,7 @@ The `result` returned, if successful, is a `WidgetStatus`. This tells you if the
 
 ### Widget Handler
 
-If you wish to be informed when the status has changed, set up a `WidgetHandler`. `WidgetHandler` is protocol you can implement, and then provide your implementation to the Afterpay SDK with `Afterpay.setWidgetHandler`. 
+If you wish to be informed when the status has changed, set up a `WidgetHandler`. `WidgetHandler` is protocol you can implement, and then provide your implementation to the Afterpay SDK with `Afterpay.setWidgetHandler`. The SDK will call your implementation when an event occurs.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The Afterpay iOS SDK provides conveniences to make your Afterpay integration exp
   - [Presenting the Widget](#presenting-the-widget)
     - [With Checkout Token](#with-checkout-token)
     - [Tokenless](#tokenless)
+    - [Widget Options](#widget-options)
     - [Updating the Widget](#updating-the-widget)
     - [Getting the Widget Status](#getting-the-widget-status)
     - [Widget Handler](#widget-handler)
@@ -525,6 +526,28 @@ Use this mode if you want a `WidgetView`, but have not yet been through an After
 
 ```swift
 WidgetView.init(amount:)
+```
+
+### Widget Options
+
+The widget has appearance options. You will provide these when you initialise the `WidgetView`. 
+
+Both initialisers take an optional second parameter: a `WidgetView.Style`. The style type contains the appearance options for the widget. At the moment, the only options for `Style` are booleans for the `logo` and the `header`. By default, they are `true`.
+
+```swift
+WidgetView.init(amount: amount, style: WidgetView.Style(logo: false, heading: false))
+```
+
+#### The `WidgetView`'s border
+
+Additionally, the `WidgetView` has a border and rounded corners. These are set on the `WidgetView`'s layer. You can adjust them, too, to fit in with your app's design:
+
+```swift
+// make rounded corners less round
+widgetView.layer.cornerRadius = 4
+
+// change the color of the border
+widgetView.layer.borderColor = UIColor.someOtherColor
 ```
 
 ### Updating the Widget

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -251,7 +251,7 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
 
     switch initialConfig {
     case let .token(token):
-      tokenAndMoney = #"\#(token)", null"#
+      tokenAndMoney = #""\#(token)", null"#
     case let .money(money):
       let moneyObj = (try? encoder.encode(money)).flatMap { String(data: $0, encoding: .utf8) } ?? "null"
       tokenAndMoney = #"null, \#(moneyObj)"#

--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -8,7 +8,7 @@
 		<script>
 			const app = window.webkit.messageHandlers.iOS;
 
-			function createAfterpayWidget(token, amount, locale) {
+			function createAfterpayWidget(token, amount, locale, style) {
 				
 				new MutationObserver(() => {
 						const height = document.getElementById("afterpay-widget-container").offsetHeight + 36; // plus extra px for margins
@@ -35,6 +35,8 @@
 					},
 					style: {
 						border: false,
+						logo: style.logo,
+						heading: style.heading,
 					}
 				});
 			}


### PR DESCRIPTION
Previously, we had hard-coded the widget’s style object in the bootstrap. Now, we pass those options from the iOS WidgetView. These can be customised by the merchant when they initialise the WidgetView.

The WidgetView is initialised with a Style struct which has the two styling options on it, logo and heading. They are both on by default. We encode that and send it to the bootstrap when we create the widget.

## Summary of Changes

- Add `Style` options to `WidgetView` initialiser

## Items of Note

The `Style` options are encoded, and sent along to the widget JS bootstrap. The bootstrap passes that to the widget when it creates it. By default, the logo and the heading are both on.

In this screenshot, the we've turned off the logo:

<img src="https://user-images.githubusercontent.com/790199/113961471-74976900-9869-11eb-9925-83b47521d8fc.png" width="350">

## Submission Checklist

- [x] Documentation is changed or added.

## Notes for testing

The Example app can be used to test this feature. It specifies the style when creating a tokenless widget. In its `MessageViewController.swift` on line 80, it creates and passes some style options:

```swift
      widgetView = try! WidgetView(amount: "200.00", style: WidgetView.Style(logo: false, heading: true))
```

This will vary the tokenless widget shown after the user taps the "Tokenless…" button on the Purchase tab's navigation bar.