### PR TITLE
Use redirect or express checkouts

### DIFF
--- a/Example/Example/Components/ComponentsViewController.swift
+++ b/Example/Example/Components/ComponentsViewController.swift
@@ -14,10 +14,6 @@ final class ComponentsViewController: UIViewController {
 
   private var scrollView: UIScrollView!
   private var pickerView: UIPickerView!
-  private var minimumAmountTextField: UITextField!
-  private var maximumAmountTextField: UITextField!
-  private var localeTextField: UITextField!
-  private var currencyTextField: UITextField!
 
   override func loadView() {
     let view = UIView()
@@ -118,22 +114,6 @@ final class ComponentsViewController: UIViewController {
     let insets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardHeight, right: 0)
     scrollView.contentInset =  insets
     scrollView.scrollIndicatorInsets = insets
-
-    let textFields: [UITextField] = [
-      minimumAmountTextField,
-      maximumAmountTextField,
-      localeTextField,
-      currencyTextField,
-    ]
-
-    let activeTextFieldOrigin = textFields
-      .first { $0.isFirstResponder }
-      .map { $0.frame.origin }
-
-    if let origin = activeTextFieldOrigin, !view.frame.contains(origin) {
-      let offset = CGPoint(x: 0, y: origin.y - keyboardHeight)
-      scrollView.setContentOffset(offset, animated: true)
-    }
   }
 
 }

--- a/Example/Example/Purchase/CartDisplay.swift
+++ b/Example/Example/Purchase/CartDisplay.swift
@@ -15,16 +15,25 @@ struct CartDisplay {
   let message: String?
   let displayTotal: String
   let payEnabled: Bool
-  let initialCheckoutOptions: CheckoutV2Options
+  let checkoutV2Options: CheckoutV2Options
 
-  init(products: [ProductDisplay], total: Decimal, currencyCode: String, initialCheckoutOptions: CheckoutV2Options) {
+  let expressCheckout: Bool
+
+  init(
+    products: [ProductDisplay],
+    total: Decimal,
+    currencyCode: String,
+    expressCheckout: Bool,
+    initialCheckoutOptions: CheckoutV2Options
+  ) {
     self.products = products
     self.message = products.isEmpty ? "Please add some items to your cart." : nil
     self.payEnabled = products.isEmpty ? false : true
 
     let formatter = CurrencyFormatter(currencyCode: currencyCode)
     self.displayTotal = formatter.displayString(from: total)
-    self.initialCheckoutOptions = initialCheckoutOptions
+    self.expressCheckout = expressCheckout
+    self.checkoutV2Options = initialCheckoutOptions
   }
 
 }

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -129,9 +129,11 @@ final class CartViewController: UIViewController, UITableViewDataSource {
         for: indexPath) as! CheckoutOptionsCell
 
       optionsCell.configure(
-        initialOptions: cart.initialCheckoutOptions,
-        eventHandler: { self.eventHandler(.optionsChanged($0)) }
-      )
+        options: cart.checkoutV2Options,
+        expressCheckout: cart.expressCheckout
+      ) { option in
+        self.eventHandler(.optionsChanged(option))
+      }
 
       cell = optionsCell
     }

--- a/Example/Example/Purchase/CheckoutOptionsCell.swift
+++ b/Example/Example/Purchase/CheckoutOptionsCell.swift
@@ -11,21 +11,25 @@ import Foundation
 
 final class CheckoutOptionsCell: UITableViewCell {
 
+  let expressLabel = UILabel()
+  let expressSwitch = UISwitch()
+  let checkoutOptionsTitle = UILabel()
   let buyNowLabel = UILabel()
   let buyNowSwitch = UISwitch()
-
   let pickupLabel = UILabel()
   let pickupSwitch = UISwitch()
-
   let shippingOptionRequiredLabel = UILabel()
   let shippingOptionRequiredSwitch = UISwitch()
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-    let title = UILabel()
-    title.font = .preferredFont(forTextStyle: .headline)
-    title.text = "Checkout options"
+    expressLabel.text = "Express checkout"
+    expressLabel.font = .preferredFont(forTextStyle: .headline)
+    expressSwitch.addTarget(self, action: #selector(expressToggled), for: .valueChanged)
+
+    checkoutOptionsTitle.font = .preferredFont(forTextStyle: .headline)
+    checkoutOptionsTitle.text = "Express checkout options"
 
     buyNowLabel.text = "Buy now"
     buyNowSwitch.addTarget(self, action: #selector(buyNowToggled), for: .valueChanged)
@@ -40,7 +44,8 @@ final class CheckoutOptionsCell: UITableViewCell {
 
     let verticalStack = UIStackView(
       arrangedSubviews: [
-        title,
+        UIStackView(arrangedSubviews: [expressLabel, expressSwitch]),
+        checkoutOptionsTitle,
         UIStackView(arrangedSubviews: [buyNowLabel, buyNowSwitch]),
         UIStackView(arrangedSubviews: [pickupLabel, pickupSwitch]),
         UIStackView(arrangedSubviews: [shippingOptionRequiredLabel, shippingOptionRequiredSwitch]),
@@ -80,17 +85,32 @@ final class CheckoutOptionsCell: UITableViewCell {
     case buyNow
     case pickup
     case shippingOptionRequired
+
+    case expressToggled
   }
 
-  func configure(initialOptions: CheckoutV2Options, eventHandler: ((Event) -> Void)? = nil) {
-    buyNowSwitch.isOn = initialOptions.buyNow ?? false
-    pickupSwitch.isOn = initialOptions.pickup ?? false
-    shippingOptionRequiredSwitch.isOn = initialOptions.shippingOptionRequired ?? true
+  func configure(options: CheckoutV2Options, expressCheckout: Bool, eventHandler: ((Event) -> Void)? = nil) {
+    expressSwitch.isOn = expressCheckout
+    configureCheckoutV2Options(enabled: expressCheckout)
+
+    buyNowSwitch.isOn = options.buyNow ?? false
+    pickupSwitch.isOn = options.pickup ?? false
+    shippingOptionRequiredSwitch.isOn = options.shippingOptionRequired ?? true
 
     self.eventHandler = eventHandler
   }
 
+  private func configureCheckoutV2Options(enabled: Bool) {
+    [buyNowSwitch, pickupSwitch, shippingOptionRequiredSwitch].forEach { $0.isEnabled = enabled }
+    [checkoutOptionsTitle, buyNowLabel, pickupLabel, shippingOptionRequiredLabel].forEach { $0.isEnabled = enabled }
+  }
+
   private var eventHandler: ((Event) -> Void)?
+
+  @objc public func expressToggled() {
+    eventHandler?(.expressToggled)
+    configureCheckoutV2Options(enabled: expressSwitch.isOn)
+  }
 
   @objc public func buyNowToggled() {
     eventHandler?(.buyNow)

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -36,7 +36,7 @@ final class PurchaseFlowController: UIViewController {
     ownedNavigationController = UINavigationController(rootViewController: productsViewController)
 
     checkoutHandler = CheckoutHandler(
-      didCommenceCheckout: logicController.loadCheckout,
+      didCommenceCheckout: logicController.loadCheckoutToken,
       onShippingAddressDidChange: logicController.selectAddress
     )
 
@@ -76,17 +76,32 @@ final class PurchaseFlowController: UIViewController {
         case .didTapPay:
           logicController.payWithAfterpay()
         case .optionsChanged(.buyNow):
-          logicController.toggleOption(\.buyNow)
+          logicController.toggleCheckoutV2Option(\.buyNow)
         case .optionsChanged(.pickup):
-          logicController.toggleOption(\.pickup)
+          logicController.toggleCheckoutV2Option(\.pickup)
         case .optionsChanged(.shippingOptionRequired):
-          logicController.toggleOption(\.shippingOptionRequired)
+          logicController.toggleCheckoutV2Option(\.shippingOptionRequired)
+        case .optionsChanged(.expressToggled):
+          logicController.toggleExpressCheckout()
         }
       }
 
       navigationController.pushViewController(cartViewController, animated: true)
 
-    case .showAfterpayCheckout(let options):
+    case .showAfterpayCheckoutV1(let checkoutURL):
+      Afterpay.presentCheckoutModally(
+        over: ownedNavigationController,
+        loading: checkoutURL
+      ) { result in
+        switch result {
+        case .success(let token):
+          logicController.success(with: token)
+        case .cancelled(let reason):
+          logicController.cancelled(with: reason)
+        }
+      }
+
+    case .showAfterpayCheckoutV2(let options):
       Afterpay.presentCheckoutV2Modally(over: ownedNavigationController, options: options) { result in
         switch result {
         case .success(let token):

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -28,6 +28,7 @@ final class PurchaseLogicController {
   typealias CheckoutResponseProvider = (
     _ email: String,
     _ amount: String,
+    _ checkoutMode: CheckoutMode,
     _ completion: @escaping (Result<CheckoutsResponse, Error>) -> Void
   ) -> Void
 
@@ -104,7 +105,7 @@ final class PurchaseLogicController {
     let formatter = CurrencyFormatter(currencyCode: currencyCode)
     let amount = formatter.string(from: total)
 
-    checkoutResponseProvider(email, amount) { [weak self] result in
+    checkoutResponseProvider(email, amount, .v2) { [weak self] result in
       let tokenResult = result.map(\.token)
       self?.commandHandler(.provideCheckoutTokenResult(tokenResult))
     }

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -14,9 +14,13 @@ final class PurchaseLogicController {
   enum Command {
     case updateProducts([ProductDisplay])
     case showCart(CartDisplay)
-    case showAfterpayCheckout(CheckoutV2Options)
+
+    case showAfterpayCheckoutV1(checkoutURL: URL)
+
+    case showAfterpayCheckoutV2(CheckoutV2Options)
     case provideCheckoutTokenResult(TokenResult)
     case provideShippingOptionsResult(ShippingOptionsResult)
+
     case showAlertForErrorMessage(String)
     case showSuccessWithMessage(String, Token)
   }
@@ -42,11 +46,13 @@ final class PurchaseLogicController {
 
   private var quantities: [UUID: UInt] = [:]
 
-  private var checkoutOptions = CheckoutV2Options(
+  private var checkoutV2Options = CheckoutV2Options(
     pickup: false,
     buyNow: false,
     shippingOptionRequired: true
   )
+
+  private var expressCheckout: Bool = true
 
   private var productDisplayModels: [ProductDisplay] {
     ProductDisplay.products(products, quantities: quantities, currencyCode: currencyCode)
@@ -81,27 +87,48 @@ final class PurchaseLogicController {
     commandHandler(.updateProducts(productDisplayModels))
   }
 
-  func toggleOption(_ option: WritableKeyPath<CheckoutV2Options, Bool?>) {
-    let currentValue = checkoutOptions[keyPath: option] ?? false
-    checkoutOptions[keyPath: option] = !currentValue
+  func toggleCheckoutV2Option(_ option: WritableKeyPath<CheckoutV2Options, Bool?>) {
+    let currentValue = checkoutV2Options[keyPath: option] ?? false
+    checkoutV2Options[keyPath: option] = !currentValue
+  }
+
+  func toggleExpressCheckout() {
+    expressCheckout.toggle()
   }
 
   func viewCart() {
     let productsInCart = productDisplayModels.filter { (quantities[$0.id] ?? 0) > 0 }
     let cart = CartDisplay(
-      products: productsInCart, total: total, currencyCode: currencyCode,
-      initialCheckoutOptions: checkoutOptions
+      products: productsInCart,
+      total: total,
+      currencyCode: currencyCode,
+      expressCheckout: expressCheckout,
+      initialCheckoutOptions: checkoutV2Options
     )
     commandHandler(.showCart(cart))
   }
 
   func payWithAfterpay() {
-    commandHandler(
-      .showAfterpayCheckout(checkoutOptions)
-    )
+    if expressCheckout {
+      commandHandler(.showAfterpayCheckoutV2(checkoutV2Options))
+    } else {
+      loadCheckoutURL(then: { self.commandHandler(.showAfterpayCheckoutV1(checkoutURL: $0)) })
+    }
   }
 
-  func loadCheckout() {
+  func loadCheckoutURL(then command: @escaping (URL) -> Void) {
+    let formatter = CurrencyFormatter(currencyCode: currencyCode)
+    let amount = formatter.string(from: total)
+
+    checkoutResponseProvider(email, amount, .v1) { result in
+      guard let url = try? result.map(\.url).get() else {
+        return
+      }
+      command(url)
+    }
+  }
+
+  func loadCheckoutToken() {
     let formatter = CurrencyFormatter(currencyCode: currencyCode)
     let amount = formatter.string(from: total)
 

--- a/Example/Example/Shared/APIClient.swift
+++ b/Example/Example/Shared/APIClient.swift
@@ -10,10 +10,21 @@ import Foundation
 
 private let session = URLSession(configuration: .default)
 
+enum CheckoutMode: Equatable {
+  case v1
+  case v2
+}
+
 private struct CheckoutsRequest: Encodable {
   let email: String
   let amount: String
-  let mode: String = "express"
+  let mode: String?
+
+  init(email: String, amount: String, checkoutMode: CheckoutMode) {
+    self.email = email
+    self.amount = amount
+    self.mode = checkoutMode == .v2 ? "express" : nil
+  }
 }
 
 struct CheckoutsResponse: Decodable {
@@ -45,7 +56,8 @@ struct APIClient {
   typealias Completion = (Result<Data, Error>) -> Void
 
   var configuration: (_ completion: @escaping Completion) -> Void
-  var checkout: (_ email: String, _ amount: String, _ completion: @escaping Completion) -> Void
+  var checkout:
+    (_ email: String, _ amount: String, _ checkoutMode: CheckoutMode, _ completion: @escaping Completion) -> Void
 }
 
 extension APIClient {
@@ -53,27 +65,29 @@ extension APIClient {
     configuration: { completion in
       session.request(.configuration, completion: completion)
     },
-    checkout: { email, amount, completion in
-      session.request(.checkout(email: email, amount: amount), completion: completion)
+    checkout: { email, amount, checkoutMode, completion in
+      session.request(.checkout(email: email, amount: amount, checkoutMode: checkoutMode), completion: completion)
     }
   )
 }
 
 private enum Endpoint {
   case configuration
-  case checkout(email: String, amount: String)
+  case checkout(email: String, amount: String, checkoutMode: CheckoutMode)
 
   var request: URLRequest? {
     switch self {
     case .configuration:
       return makeRequest("/configuration")
-    case let .checkout(email, amount):
+    case let .checkout(email, amount, checkoutMode):
       return makeRequest("/checkouts") { request in
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         // A failed encoding operation here would represent programmer error
         // swiftlint:disable:next force_try
-        request.httpBody = try! JSONEncoder().encode(CheckoutsRequest(email: email, amount: amount))
+        request.httpBody = try! JSONEncoder().encode(
+          CheckoutsRequest(email: email, amount: amount, checkoutMode: checkoutMode)
+        )
       }
     }
   }

--- a/Example/Example/Shared/Repository.swift
+++ b/Example/Example/Shared/Repository.swift
@@ -59,9 +59,10 @@ final class Repository {
   func checkout(
     email: String,
     amount: String,
+    checkoutMode: CheckoutMode,
     completion: @escaping (Result<CheckoutsResponse, Error>) -> Void
   ) {
-    apiClient.checkout(email, amount) { result in
+    apiClient.checkout(email, amount, checkoutMode) { result in
       completion(result.flatMap { data in
         Result { try JSONDecoder().decode(CheckoutsResponse.self, from: data) }
       })

--- a/Example/Example/SwiftUI/SwiftUIExample.swift
+++ b/Example/Example/SwiftUI/SwiftUIExample.swift
@@ -62,6 +62,7 @@ private struct CheckoutView: View {
         self.repository.checkout(
           email: Settings.email,
           amount: "30.00",
+          checkoutMode: .v1,
           completion: self.checkoutResultHandler
         )
       }

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -47,7 +47,7 @@ public func presentCheckoutModally(
 
 /// Optional checkout flags to set when using `presentCheckoutV2Modally` that change the experience
 /// for the end user within the checkout.
-public struct CheckoutV2Options {
+public struct CheckoutV2Options: Equatable {
 
   /// Setting `pickup` to `true` when working with an express order will allow you to specify a
   /// pickup address when creating an order token via the `shipping` object. This also prevents the


### PR DESCRIPTION
⚠️ [This PR is build on top of another](https://github.com/afterpay/sdk-ios/pull/147) ⚠️ It will be hard to review until those are also merged. They are awaiting QA.

Previously, opening the checkout would always give you the express checkout. We’ve added a switch to the `CheckoutOptionsCell` which turns off the express checkout, and that allows you to open the regular v1 checkout.

## Summary of Changes

- Add v1 checkout mode.

### V1 Checkout (redirect)
<img src="https://user-images.githubusercontent.com/790199/114965267-9ae58600-9eb3-11eb-8537-95d94b0bb7f6.png" width="300">

### V2 Checkout (express / postMessage)
<img src="https://user-images.githubusercontent.com/790199/114965327-b781be00-9eb3-11eb-9d85-27a3e0ae3998.png" width="300">

## Additional

The Example app also contained a reproducible crash bug:

* Launch the Example app and go to the Components tab
* Go back to the purchase tab, add something to the card, view the cart, and select 'pay now'
* In the payment checkout, or in the checkout login screen, tap on a text field such that the on-screen keyboard appears

**Expected:** the on screen keyboard appears
**Actual:** the app crashes.

Interestingly, this only happened if you went to the Components tab before the checkout.

The reason for this is when the keyboard resized, the notification center called the `adjustForKeyboard` method on the ComponentsViewController. It only calls this method if the ComponentsViewController has been displayed at least once. In that method, it referred to text field properties. They were implicitly-unwrapped optionals. I had removed their assignment in 88caa3c7e7853527b79774618479922589cf0e16, but never removed the properties themselves. Since they were implicitly unwrapped, and never had a value assigned, this was a crash.

## Submission Checklist

- [x] Tests are included.
- [x] Documentation is changed or added.
