### PR TITLE
Do not inject afterpay.js script tag

### DIFF
--- a/Sources/Afterpay/Model/Environment.swift
+++ b/Sources/Afterpay/Model/Environment.swift
@@ -21,14 +21,6 @@ import Foundation
     URL(string: "https://afterpay.github.io/sdk-example-server/widget-bootstrap.html")!
   }
 
-  var widgetScriptURL: URL {
-    /*
-    The `merchant_key` parameter is deprecated. It will be removed in a later version of `afterpay.js`.
-    The value `demo` is sufficient until then.
-    */
-    URL(string: "https://portal.sandbox.afterpay.com/afterpay.js?merchant_key=demo")!
-  }
-
   var bootstrapCacheDisplayName: String { "afterpay.com" }
 
 }

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -116,18 +116,8 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     preferences.javaScriptEnabled = true
     preferences.javaScriptCanOpenWindowsAutomatically = true
 
-    let script =
-      """
-      var script = document.createElement('script');
-      script.src = '\(configuration.environment.widgetScriptURL.absoluteString)';
-      script.type = 'text/javascript';
-      document.getElementsByTagName('head')[0].appendChild(script);
-      """
-    let userScript = WKUserScript(source: script, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-
     let userContentController = WKUserContentController()
     userContentController.add(self, name: "iOS")
-    userContentController.addUserScript(userScript)
 
     let bootstrapConfiguration = WKWebViewConfiguration()
     bootstrapConfiguration.processPool = WKProcessPool()


### PR DESCRIPTION
Previously, we were injecting the script tag via the WidgetView. This meant the WidgetView could decide the URL from which we could get afterpay.js. This turned out to not be that advantageous because staging and prod are rarely meaningfully different from our point of view.

Instead, we’ll move the script tag back into the bootstrap html, but we’ll put it in the header this time. That way it will be ready by the time we can execute the rest of the scripts. This will speed things up for us, (and make it work on Android!)
