### PR TITLE
[Xcode 12.5] Make super class init available internally

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
 
   build-and-test:
     name: Build and Test
-    runs-on: macos-latest
+    runs-on: macos-11.0
 
     env:
       destination: platform=iOS Simulator,name=iPhone 11,OS=14.5

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
 
   build-and-test:
     name: Build and Test
-    runs-on: macos-11.0
+    runs-on: macos-latest
 
     env:
       destination: platform=iOS Simulator,name=iPhone 11,OS=14.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 env:
   afterpay-scheme: Afterpay
-  DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      destination: platform=iOS Simulator,name=iPhone 11,OS=14.0
+      destination: platform=iOS Simulator,name=iPhone 11,OS=14.5
       example-scheme: Example
       workspace: Afterpay.xcworkspace
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 env:
   afterpay-scheme: Afterpay
-  DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-11.0
 
     env:
-      destination: platform=iOS Simulator,name=iPhone 11,OS=14.5
+      destination: platform=iOS Simulator,name=iPhone 11,OS=14.0
       example-scheme: Example
       workspace: Afterpay.xcworkspace
 

--- a/Sources/Afterpay/Wrappers/ObjcWrapper.swift
+++ b/Sources/Afterpay/Wrappers/ObjcWrapper.swift
@@ -15,12 +15,10 @@ public final class ObjcWrapper: NSObject {
   @available(*, unavailable)
   public override init() {}
 
-  /// Cannot be instantiated, instances will be of type CheckoutResultSuccess or
-  /// CheckoutResultCancelled
+  /// Should not be instantiated, instances should be of type CheckoutResultSuccess or CheckoutResultCancelled
   @objc(APCheckoutResult)
   public class CheckoutResult: NSObject {
-    @available(*, unavailable)
-    override init() {}
+    internal override init() {}
 
     static func success(token: String) -> CheckoutResultSuccess {
       CheckoutResultSuccess(token: token)
@@ -49,12 +47,11 @@ public final class ObjcWrapper: NSObject {
     }
   }
 
-  /// Cannot be instantiated, instances will be of type CancellationReasonUserInitiated,
-  /// CancellationReasonNetworkError or CancellationReasonInvalidURL
   @objc(APCancellationReason)
   public class CancellationReason: NSObject {
-    @available(*, unavailable)
-    override init() {}
+    /// Should not be instantiated, instances should be of type CancellationReasonUserInitiated,
+    /// CancellationReasonNetworkError or CancellationReasonInvalidURL
+    internal override init() {}
 
     static func userInitiated() -> CancellationReasonUserInitiated {
       CancellationReasonUserInitiated(())


### PR DESCRIPTION
Previously, we had marked some NSObject superclasses’ inits as unavailable. That way, people won’t accidentally instantiate them:

```
  class Super: NSObject {
    @available(*, unavailable)
    override init() { }
  }

  class Sub: Super {
    let s: String
    init(s: String) { self.s = s }
  }
```

However, in Swift 5.4, this changed. The subclasses’ inits do not compile because they cannot call the super.

Instead, we mark the super classes’ initialiser as `internal` so that consumers of the Afterpay SDK cannot accidentally initialise the super.
