### PR TITLE
Add UI Tests for Example app

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         npm install
         npm run build
-        npm run start
+        npm run start &
       env:
         AFTERPAY_MERCHANT_ID: ${{ secrets.AFTERPAY_MERCHANT_ID_AU }}
         AFTERPAY_SECRET_KEY: ${{ secrets.AFTERPAY_SECRET_KEY_AU }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       destination: platform=iOS Simulator,name=iPhone 11,OS=14.0
       example-scheme: Example
+      example-ui-test-scheme: ExampleUITests
       workspace: Afterpay.xcworkspace
 
     steps:
@@ -81,6 +82,12 @@ jobs:
         AFTERPAY_SECRET_KEY: ${{ secrets.AFTERPAY_SECRET_KEY_AU }}
         AFTERPAY_REGION: AU
 
+    - name: UI Test SDK Project
+      run: |
+        xcodebuild test \
+          -workspace ${{ env.workspace }} \
+          -scheme ${{ env.example-ui-test-scheme }} \
+          -destination '${{ env.destination }}'
 
   validate-cocoapods:
     name: Validate Pod

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,12 @@ jobs:
 
     - name: UI Test SDK Project
       run: |
-        xcodebuild test \
+        xcodebuild build-for-testing \
+          -workspace ${{ env.workspace }} \
+          -scheme ${{ env.example-ui-test-scheme }} \
+          -destination '${{ env.destination }}'
+          
+        xcodebuild test-without-building \
           -workspace ${{ env.workspace }} \
           -scheme ${{ env.example-ui-test-scheme }} \
           -destination '${{ env.destination }}'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,6 +58,29 @@ jobs:
           -workspace ${{ env.workspace }} \
           -scheme ${{ env.example-scheme }} \
           -destination '${{ env.destination }}'
+          
+    - name: Checkout Example Server
+      uses: actions/checkout@v2
+      with:
+        repository: afterpay/sdk-example-server
+        path: ./example-server
+        
+    - name: Setup Example Server
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+        
+    - name: Run Example Server
+      working-directory: ./example-server
+      run: |
+        npm install
+        npm run build
+        npm run start
+      env:
+        AFTERPAY_MERCHANT_ID: ${{ secrets.AFTERPAY_MERCHANT_ID_AU }}
+        AFTERPAY_SECRET_KEY: ${{ secrets.AFTERPAY_SECRET_KEY_AU }}
+        AFTERPAY_REGION: AU
+
 
   validate-cocoapods:
     name: Validate Pod

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 				55432831263B7EC2005512E4 /* Sources */,
 				55432832263B7EC2005512E4 /* Frameworks */,
 				55432833263B7EC2005512E4 /* Resources */,
+				5543283F263BB5EE005512E4 /* Check Example Server is running */,
 			);
 			buildRules = (
 			);
@@ -417,6 +418,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		5543283F263BB5EE005512E4 /* Check Example Server is running */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check Example Server is running";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "curl localhost:3000 || (echo \"Cannot connect to the Example Server... Has it been started?\" ; exit 1) \n";
+		};
 		6632E0B0248A0288007F0BD9 /* swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		157C65AD25D0F19900115149 /* Result+Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157C65AC25D0F19900115149 /* Result+Fold.swift */; };
 		5539D82C25EDE97E0088BC97 /* ControlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5539D82B25EDE97E0088BC97 /* ControlCell.swift */; };
 		5539D83025F068F90088BC97 /* CheckoutOptionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5539D82F25F068F90088BC97 /* CheckoutOptionsCell.swift */; };
+		55432838263B7EC2005512E4 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55432837263B7EC2005512E4 /* ExampleUITests.swift */; };
 		55FA7270260025DC0006EFCB /* WidgetHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FA726F260025DC0006EFCB /* WidgetHandler.swift */; };
 		660072B724A1B55E00E9A2BC /* TextSettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660072B624A1B55E00E9A2BC /* TextSettingCell.swift */; };
 		6620B5D224934FB3004162BC /* AppFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6620B5D124934FB3004162BC /* AppFlowController.swift */; };
@@ -52,6 +53,16 @@
 		9490D1D624D8ED4F001E1EFC /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9490D1D524D8ED4F001E1EFC /* Repository.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		5543283A263B7EC2005512E4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 668F161624877F950040345C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 668F161D24877F950040345C;
+			remoteInfo = Example;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		66F9767A24999F5C001D38FA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -74,6 +85,9 @@
 		157C65AC25D0F19900115149 /* Result+Fold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+Fold.swift"; sourceTree = "<group>"; };
 		5539D82B25EDE97E0088BC97 /* ControlCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCell.swift; sourceTree = "<group>"; };
 		5539D82F25F068F90088BC97 /* CheckoutOptionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutOptionsCell.swift; sourceTree = "<group>"; };
+		55432835263B7EC2005512E4 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		55432837263B7EC2005512E4 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
+		55432839263B7EC2005512E4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55FA726F260025DC0006EFCB /* WidgetHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetHandler.swift; sourceTree = "<group>"; };
 		660072B624A1B55E00E9A2BC /* TextSettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSettingCell.swift; sourceTree = "<group>"; };
 		6620B5D124934FB3004162BC /* AppFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowController.swift; sourceTree = "<group>"; };
@@ -116,6 +130,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		55432832263B7EC2005512E4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		668F161B24877F950040345C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -135,6 +156,15 @@
 				157C65AC25D0F19900115149 /* Result+Fold.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		55432836263B7EC2005512E4 /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				55432837263B7EC2005512E4 /* ExampleUITests.swift */,
+				55432839263B7EC2005512E4 /* Info.plist */,
+			);
+			path = ExampleUITests;
 			sourceTree = "<group>";
 		};
 		664722A524A5D98D0079B1FB /* Shared */ = {
@@ -217,6 +247,7 @@
 			isa = PBXGroup;
 			children = (
 				668F162024877F950040345C /* Example */,
+				55432836263B7EC2005512E4 /* ExampleUITests */,
 				668F161F24877F950040345C /* Products */,
 				668F163A248786740040345C /* Frameworks */,
 			);
@@ -228,6 +259,7 @@
 			isa = PBXGroup;
 			children = (
 				668F161E24877F950040345C /* Example.app */,
+				55432835263B7EC2005512E4 /* ExampleUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -282,6 +314,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		55432834263B7EC2005512E4 /* ExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5543283E263B7EC2005512E4 /* Build configuration list for PBXNativeTarget "ExampleUITests" */;
+			buildPhases = (
+				55432831263B7EC2005512E4 /* Sources */,
+				55432832263B7EC2005512E4 /* Frameworks */,
+				55432833263B7EC2005512E4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5543283B263B7EC2005512E4 /* PBXTargetDependency */,
+			);
+			name = ExampleUITests;
+			productName = ExampleUITests;
+			productReference = 55432835263B7EC2005512E4 /* ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		668F161D24877F950040345C /* Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 668F163224877F980040345C /* Build configuration list for PBXNativeTarget "Example" */;
@@ -310,10 +360,14 @@
 		668F161624877F950040345C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1150;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = Afterpay;
 				TargetAttributes = {
+					55432834263B7EC2005512E4 = {
+						CreatedOnToolsVersion = 12.5;
+						TestTargetID = 668F161D24877F950040345C;
+					};
 					668F161D24877F950040345C = {
 						CreatedOnToolsVersion = 11.5;
 						LastSwiftMigration = 1150;
@@ -337,11 +391,19 @@
 			projectRoot = "";
 			targets = (
 				668F161D24877F950040345C /* Example */,
+				55432834263B7EC2005512E4 /* ExampleUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		55432833263B7EC2005512E4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		668F161C24877F950040345C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -376,6 +438,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		55432831263B7EC2005512E4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55432838263B7EC2005512E4 /* ExampleUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		668F161A24877F950040345C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -421,6 +491,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		5543283B263B7EC2005512E4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 668F161D24877F950040345C /* Example */;
+			targetProxy = 5543283A263B7EC2005512E4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		668F162C24877F980040345C /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -433,6 +511,46 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		5543283C263B7EC2005512E4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KBY3G4JPGC;
+				INFOPLIST_FILE = ExampleUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.afterpay.ExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Example;
+			};
+			name = Debug;
+		};
+		5543283D263B7EC2005512E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KBY3G4JPGC;
+				INFOPLIST_FILE = ExampleUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.afterpay.ExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Example;
+			};
+			name = Release;
+		};
 		668F163024877F980040345C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -607,6 +725,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5543283E263B7EC2005512E4 /* Build configuration list for PBXNativeTarget "ExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5543283C263B7EC2005512E4 /* Debug */,
+				5543283D263B7EC2005512E4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		668F161924877F950040345C /* Build configuration list for PBXProject "Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -517,7 +517,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = KBY3G4JPGC;
 				INFOPLIST_FILE = ExampleUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -537,7 +536,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = KBY3G4JPGC;
 				INFOPLIST_FILE = ExampleUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/ExampleUITests.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/ExampleUITests.xcscheme
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "668F161D24877F950040345C"
-               BuildableName = "Example.app"
-               BlueprintName = "Example"
-               ReferencedContainer = "container:Example.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -50,22 +34,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "668F161D24877F950040345C"
-            BuildableName = "Example.app"
-            BlueprintName = "Example"
-            ReferencedContainer = "container:Example.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-com.afterpay.widget-enabled YES"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,16 +41,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "668F161D24877F950040345C"
-            BuildableName = "Example.app"
-            BlueprintName = "Example"
-            ReferencedContainer = "container:Example.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -50,6 +50,7 @@ final class CartViewController: UIViewController, UITableViewDataSource {
 
     let payButton: UIButton = PaymentButton()
     payButton.isEnabled = cart.payEnabled
+    payButton.accessibilityIdentifier = "payNow"
     payButton.addTarget(self, action: #selector(didTapPay), for: .touchUpInside)
 
     view.addSubview(tableView)

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -1,0 +1,18 @@
+//
+//  ExampleUITests.swift
+//  ExampleUITests
+//
+//  Created by Huw Rowlands on 30/4/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import XCTest
+
+class ExampleUITests: XCTestCase {
+
+  func testExampleAppLaunches() throws {
+    let app = XCUIApplication()
+    app.launch()
+  }
+
+}

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -8,11 +8,39 @@
 
 import XCTest
 
-class ExampleUITests: XCTestCase {
+final class ExampleUITests: XCTestCase {
+
+  private let app = XCUIApplication()
+
+  override func setUp() {
+    app.launchArguments = ["-com.afterpay.widget-enabled", "YES"]
+    app.launch()
+  }
 
   func testExampleAppLaunches() throws {
-    let app = XCUIApplication()
-    app.launch()
+    app.staticTexts["+"].firstMatch.tap()
+
+    app.staticTexts["View Cart"].tap()
+
+    XCTAssertTrue(app.buttons["payNow"].waitForExistence(timeout: 0.5))
+    app.buttons["payNow"].tap()
+
+    XCTAssertTrue(app.buttons["Log In"].waitForExistence(timeout: 10)) /* big timeout because it takes ages to load */
+
+    app.swipeDown()
+
+    XCTAssertTrue(app.staticTexts["Are you sure you want to cancel the payment?"].waitForExistence(timeout: 0.5))
+
+    app.buttons["Yes"].tap()
+  }
+
+  func testTokenlessWidget() throws {
+    app.buttons["Tokenless…"].tap()
+
+    XCTAssertTrue(app.staticTexts["Due today"].waitForExistence(timeout: 3))
+    XCTAssertTrue(app.staticTexts["Today"].waitForExistence(timeout: 0.5))
+    XCTAssertTrue(app.staticTexts["In 2 weeks"].waitForExistence(timeout: 0.5))
+    XCTAssertTrue(app.staticTexts["In 4 weeks"].waitForExistence(timeout: 0.5))
   }
 
 }

--- a/Example/ExampleUITests/Info.plist
+++ b/Example/ExampleUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Sources/Afterpay/Wrappers/SwiftUIWrapper.swift
+++ b/Sources/Afterpay/Wrappers/SwiftUIWrapper.swift
@@ -43,6 +43,7 @@ struct URLItem: Identifiable {
 
 }
 
+@available(iOS 13.0, *)
 struct SwiftUIWrapper: UIViewControllerRepresentable {
 
   let checkoutURL: URL


### PR DESCRIPTION
Let's add some UI Tests to the Example app. This has been requested specifically by QA engineers wishing to improve the test coverage of the checkout and widget.

We've added a new test target to the Example project: `ExampleUITests`. At the moment, the only test in there just launches the app then closes. It passes, and is just there as a stub. We'll add some more in later PRs.

To run, the app requires the example server to be running. We've set up GitHub Actions to start the example server in the steps _before_ it runs the UI tests.