### PR TITLE
End to end test fixups

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,6 +93,12 @@ jobs:
           -workspace ${{ env.workspace }} \
           -scheme ${{ env.example-ui-test-scheme }} \
           -destination '${{ env.destination }}'
+            
+    - name: Upload UI test artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: xcresults
+        path: Logs/Test/*
 
   validate-cocoapods:
     name: Validate Pod

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -95,6 +95,7 @@ jobs:
           -destination '${{ env.destination }}'
             
     - name: Upload UI test artifacts
+      if: ${{ always() }}
       uses: actions/upload-artifact@v2
       with:
         name: xcresults

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,7 +98,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: xcresults
-        path: Logs/Test/*
+        path: /Users/runner/Library/Developer/Xcode/DerivedData/Afterpay-*/Logs/Test/*
 
   validate-cocoapods:
     name: Validate Pod

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -37,7 +37,7 @@ final class ExampleUITests: XCTestCase {
   func testTokenlessWidget() throws {
     app.buttons["Tokenless…"].tap()
 
-    XCTAssertTrue(app.staticTexts["Due today"].waitForExistence(timeout: 3))
+    XCTAssertTrue(app.staticTexts["Due today"].waitForExistence(timeout: 10))
     XCTAssertTrue(app.staticTexts["Today"].waitForExistence(timeout: 0.5))
     XCTAssertTrue(app.staticTexts["In 2 weeks"].waitForExistence(timeout: 0.5))
     XCTAssertTrue(app.staticTexts["In 4 weeks"].waitForExistence(timeout: 0.5))

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -35,7 +35,7 @@ final class ExampleUITests: XCTestCase {
     app.buttons["Yes"].tap()
   }
 
-  func testTokenlessWidget() throws {
+  func testTokenlessWidgetAppears() throws {
     app.buttons["Tokenless…"].tap()
 
     XCTAssertTrue(app.staticTexts["Due today"].waitForExistence(timeout: 10))

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -17,7 +17,7 @@ final class ExampleUITests: XCTestCase {
     app.launch()
   }
 
-  func testExampleAppLaunches() throws {
+  func testCheckoutShows() throws {
     app.staticTexts["+"].firstMatch.tap()
 
     app.staticTexts["View Cart"].tap()
@@ -25,7 +25,8 @@ final class ExampleUITests: XCTestCase {
     XCTAssertTrue(app.buttons["payNow"].waitForExistence(timeout: 0.5))
     app.buttons["payNow"].tap()
 
-    XCTAssertTrue(app.buttons["Log In"].waitForExistence(timeout: 10)) /* big timeout because it takes ages to load */
+    // we assert _some_ type of web view is shown
+    XCTAssertTrue(app.webViews.firstMatch.waitForExistence(timeout: 2))
 
     app.swipeDown()
 


### PR DESCRIPTION
Fix up some of the UI Tests:

* Upload xcresults file to the GitHub actions artifacts
* Increase timeout on the widget, in case it's taking too long
* Instead of asserting something about the checkout, let's just assert that a web view is loading.  We can't make too many guarantees about the contents of the checkout webview, so let's not try in this test.