### PR TITLE
Embed widget bootstrap HTML inside app

### DIFF
--- a/Sources/Afterpay/Model/Environment.swift
+++ b/Sources/Afterpay/Model/Environment.swift
@@ -17,10 +17,36 @@ import Foundation
     URL(string: "https://static.afterpay.com/mobile-sdk/bootstrap/index.html")!
   }
 
-  var widgetBootstrapURL: URL {
-    URL(string: "https://afterpay.github.io/sdk-example-server/widget-bootstrap.html")!
+  var widgetBootstrapScriptURL: URL {
+    URL(string: "https://afterpay.github.io/sdk-example-server/widget-bootstrap.js")!
+  }
+
+  var afterpayJsURL: String {
+    switch self {
+    case .sandbox:
+      return "https://portal.sandbox.afterpay.com/afterpay.js?merchant_key=demo"
+    case .production:
+      return "https://portal.afterpay.com/afterpay.js?merchant_key=demo"
+    }
   }
 
   var bootstrapCacheDisplayName: String { "afterpay.com" }
+
+  var widgetBootstrapHTML: String {
+    """
+    <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+        <script src="\(afterpayJsURL)"></script>
+        <script src="\(widgetBootstrapScriptURL.absoluteString)"></script>
+
+      </head>
+      <body>
+        <div id="afterpay-widget-container" style="margin: 16px 0px"></div>
+      </body>
+    </html>
+    """
+  }
 
 }

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -129,11 +129,9 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     webView.allowsLinkPreview = false
     webView.scrollView.isScrollEnabled = false
 
-    webView.load(
-      URLRequest(
-        url: getConfiguration()!.environment.widgetBootstrapURL,
-        cachePolicy: .reloadIgnoringLocalCacheData
-      )
+    webView.loadHTMLString(
+      configuration.environment.widgetBootstrapHTML,
+      baseURL: configuration.environment.checkoutBootstrapURL
     )
 
     addSubview(webView)


### PR DESCRIPTION
Previously, we were loading the bootstrap HTML + JS from GitHub pages. This was okay, except when we wanted to change environments between staging and production. The URL for Afterpay.js needs to change, and since the HTML was centrally hosted, there was no way to change it.

Instead, we can host just the bootstrap’s JS centrally on GitHub, and keep the HTML inside the app. This way, we can adjust the URLs it needs depending on the environment.

A different call is used to start the web view. Instead of `webView.load`, we use `webView.loadHTMLString(:baseURL:)`. In there we pass the HTML, but we also give the widget bootstrap URL to use as a `baseURL`. That prevents cross site scripting issues occurring inside the webview.

## Summary of Changes

- The widget bootstrap HTML is embedded in the app.
