### PR TITLE
Provide a minimum height of 200 to the widget

### DIFF
--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -165,7 +165,10 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
       webView.bottomAnchor.constraint(equalTo: bottomAnchor),
     ]
 
-    NSLayoutConstraint.activate(webViewConstraints)
+    let heightConstraint = webView.heightAnchor.constraint(greaterThanOrEqualToConstant: 200)
+    heightConstraint.priority = .defaultLow
+
+    NSLayoutConstraint.activate(webViewConstraints + [heightConstraint])
   }
 
   private func setupBorder() {


### PR DESCRIPTION
Previously, we were not assigning a default height to the widget. This meant if it took a while to load, it would have 0 height. This looked bad. If we give a min height of 200, there will be enough room to show the widget's spinner.

Spinner looks like:
<img src="https://user-images.githubusercontent.com/790199/117241714-16b16d80-ae77-11eb-9cbb-4e5cdea8d798.png" width="350">
