### PR TITLE
Animate changes to the widget’s height

### DIFF
--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -36,7 +36,16 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
   /// The bootstrap JS will send us resize events, which we'll use to populate this value
   private var suggestedHeight: Int? {
     didSet {
-      invalidateIntrinsicContentSize()
+
+      if UIAccessibility.isReduceMotionEnabled || oldValue == 0 {
+        invalidateIntrinsicContentSize()
+      } else {
+        UIView.animate(withDuration: 0.1) {
+          self.invalidateIntrinsicContentSize()
+          self.superview?.setNeedsLayout()
+          self.superview?.layoutIfNeeded()
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Previously, if the suggested height of the widget changed, we’d invalidate the intrinsic content size and leave it. Now, we animate the change so that it looks nice.
