### PR TITLE
Set user agent to include info on AfterpaySDK

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		55432830263A61C4005512E4 /* CombineWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5543282F263A61C4005512E4 /* CombineWrapper.swift */; };
 		557511BB264259C30040CC51 /* CombineWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BA264259C30040CC51 /* CombineWrapperTests.swift */; };
 		557511BF2644CAA50040CC51 /* WKWebView+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */; };
+		557511C12644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */; };
 		55A2D307261BB36C00D8E23A /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A2D306261BB36C00D8E23A /* Money.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
@@ -87,6 +88,7 @@
 		5543282F263A61C4005512E4 /* CombineWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineWrapper.swift; sourceTree = "<group>"; };
 		557511BA264259C30040CC51 /* CombineWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineWrapperTests.swift; sourceTree = "<group>"; };
 		557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Cache.swift"; sourceTree = "<group>"; };
+		557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebViewConfiguration+UserAgent.swift"; sourceTree = "<group>"; };
 		55A2D306261BB36C00D8E23A /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				15EC67D125E6217F007DFEA8 /* OSLog+Afterpay.swift */,
 				157E88D025CBCA49007E54C4 /* Result+Fold.swift */,
 				557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */,
+				557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -527,6 +530,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				557511C12644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift in Sources */,
 				66639B5424D2619200C68558 /* SVGView.swift in Sources */,
 				66E255AE24E3C14600C81F20 /* Strings.swift in Sources */,
 				6615F99B24D14620005036F1 /* SVG.swift in Sources */,

--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		551BEDFC25F9C56600FDF9EE /* WidgetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDFB25F9C56600FDF9EE /* WidgetEvent.swift */; };
 		55432830263A61C4005512E4 /* CombineWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5543282F263A61C4005512E4 /* CombineWrapper.swift */; };
 		557511BB264259C30040CC51 /* CombineWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BA264259C30040CC51 /* CombineWrapperTests.swift */; };
+		557511BF2644CAA50040CC51 /* WKWebView+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */; };
 		55A2D307261BB36C00D8E23A /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A2D306261BB36C00D8E23A /* Money.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
@@ -85,6 +86,7 @@
 		551BEDFB25F9C56600FDF9EE /* WidgetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEvent.swift; sourceTree = "<group>"; };
 		5543282F263A61C4005512E4 /* CombineWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineWrapper.swift; sourceTree = "<group>"; };
 		557511BA264259C30040CC51 /* CombineWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineWrapperTests.swift; sourceTree = "<group>"; };
+		557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Cache.swift"; sourceTree = "<group>"; };
 		55A2D306261BB36C00D8E23A /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 			children = (
 				15EC67D125E6217F007DFEA8 /* OSLog+Afterpay.swift */,
 				157E88D025CBCA49007E54C4 /* Result+Fold.swift */,
+				557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -560,6 +563,7 @@
 				946388FE24DD077F00A1227A /* InfoWebViewController.swift in Sources */,
 				66EE9BD724DCEC3E00A81C19 /* LinkTextView.swift in Sources */,
 				661D431F257DC86C00ACCDE1 /* ShippingAddress.swift in Sources */,
+				557511BF2644CAA50040CC51 /* WKWebView+Cache.swift in Sources */,
 				6605666324E5199500DA588E /* Locales.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -92,6 +92,7 @@ final class CheckoutV2ViewController:
 
     let bootstrapConfiguration = WKWebViewConfiguration()
     bootstrapConfiguration.processPool = processPool
+    bootstrapConfiguration.applicationNameForUserAgent = WKWebViewConfiguration.appNameForUserAgent
     bootstrapConfiguration.preferences = preferences
     bootstrapConfiguration.userContentController = userContentController
 

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -139,16 +139,11 @@ final class CheckoutV2ViewController:
     super.viewDidAppear(animated)
 
     let webView: WKWebView = bootstrapWebView
-    let load: () -> Void = { [bootstrapURL] in webView.load(URLRequest(url: bootstrapURL)) }
 
-    // Remove bootstrap disk caches so that the latest bootstrap is loaded
-    let dataStore = webView.configuration.websiteDataStore
-    let dataTypes: Set<String> = [WKWebsiteDataTypeDiskCache]
-    let displayName = configuration.environment.bootstrapCacheDisplayName
-
-    dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
-      let bootstrapRecords = records.filter { record in record.displayName == displayName }
-      dataStore.removeData(ofTypes: dataTypes, for: bootstrapRecords, completionHandler: load)
+    webView.removeCache(
+      for: configuration.environment.bootstrapCacheDisplayName
+    ) {
+      [bootstrapURL] in webView.load(URLRequest(url: bootstrapURL))
     }
   }
 

--- a/Sources/Afterpay/Checkout/CheckoutWebViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutWebViewController.swift
@@ -34,7 +34,10 @@ final class CheckoutWebViewController:
   }
 
   override func loadView() {
-    view = WKWebView()
+    let config = WKWebViewConfiguration()
+    config.applicationNameForUserAgent = WKWebViewConfiguration.appNameForUserAgent
+
+    view = WKWebView(frame: .zero, configuration: config)
   }
 
   override func viewDidLoad() {

--- a/Sources/Afterpay/Helpers/WKWebView+Cache.swift
+++ b/Sources/Afterpay/Helpers/WKWebView+Cache.swift
@@ -1,0 +1,24 @@
+//
+//  WKWebView+Cache.swift
+//  Afterpay
+//
+//  Created by Huw Rowlands on 7/5/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import WebKit
+
+extension WKWebView {
+
+  /// Remove disk caches so that the latest bootstrap is loaded
+  func removeCache(for displayName: String, completionHandler: @escaping () -> Void) {
+    let dataStore = configuration.websiteDataStore
+    let dataTypes: Set<String> = [WKWebsiteDataTypeDiskCache]
+
+    dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
+      let bootstrapRecords = records.filter { record in record.displayName == displayName }
+      dataStore.removeData(ofTypes: dataTypes, for: bootstrapRecords, completionHandler: completionHandler)
+    }
+  }
+
+}

--- a/Sources/Afterpay/Helpers/WKWebViewConfiguration+UserAgent.swift
+++ b/Sources/Afterpay/Helpers/WKWebViewConfiguration+UserAgent.swift
@@ -1,0 +1,19 @@
+//
+//  WKWebView+UserAgent.swift
+//  Afterpay
+//
+//  Created by Huw Rowlands on 7/5/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import WebKit
+
+extension WKWebViewConfiguration {
+
+  static var appNameForUserAgent: String? {
+    Bundle(for: CheckoutV2ViewController.self)
+      .infoDictionary?["CFBundleShortVersionString"]
+      .map { "Afterpay-iOS-SDK/\($0)" }
+  }
+
+}

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -130,6 +130,7 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
 
     let bootstrapConfiguration = WKWebViewConfiguration()
     bootstrapConfiguration.processPool = WKProcessPool()
+    bootstrapConfiguration.applicationNameForUserAgent = WKWebViewConfiguration.appNameForUserAgent
     bootstrapConfiguration.preferences = preferences
     bootstrapConfiguration.userContentController = userContentController
 
@@ -139,10 +140,10 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     webView.scrollView.isScrollEnabled = false
 
     webView.removeCache(for: configuration.environment.bootstrapCacheDisplayName) { [configuration] in
-    webView.loadHTMLString(
-      configuration.environment.widgetBootstrapHTML,
-      baseURL: configuration.environment.checkoutBootstrapURL
-    )
+      webView.loadHTMLString(
+        configuration.environment.widgetBootstrapHTML,
+        baseURL: configuration.environment.checkoutBootstrapURL
+      )
     }
 
     self.webView = webView

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -133,16 +133,19 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     bootstrapConfiguration.preferences = preferences
     bootstrapConfiguration.userContentController = userContentController
 
-    webView = WKWebView(frame: .zero, configuration: bootstrapConfiguration)
+    let webView: WKWebView = WKWebView(frame: .zero, configuration: bootstrapConfiguration)
     webView.navigationDelegate = self
     webView.allowsLinkPreview = false
     webView.scrollView.isScrollEnabled = false
 
+    webView.removeCache(for: configuration.environment.bootstrapCacheDisplayName) { [configuration] in
     webView.loadHTMLString(
       configuration.environment.widgetBootstrapHTML,
       baseURL: configuration.environment.checkoutBootstrapURL
     )
+    }
 
+    self.webView = webView
     addSubview(webView)
   }
 


### PR DESCRIPTION
Previously, we were just sending the WKWebView user agent as it comes. That tells us a lot, but not the version of the Afterpay SDK. We now include that at the end.

#### Before
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148`

#### Now
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Afterpay-iOS-SDK/2.0.0`

## Additional

- We also clear the bootstrap cache more explicitly. This helps us just clear the cache for Afterpay assets, not assets hosted elsewhere.
