### PR TITLE
Add extra spinner on top of widget's WebView

### DIFF
--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -13,6 +13,13 @@ import WebKit
 public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHandler {
 
   private var webView: WKWebView!
+  private lazy var activityView: UIActivityIndicatorView = {
+    let view = UIActivityIndicatorView(style: .gray)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.hidesWhenStopped = true
+    view.startAnimating()
+    return view
+  }()
 
   private enum Mode {
     case token(String)
@@ -114,11 +121,25 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     )
 
     setupWebView()
-    setupConstraints()
+    setupWebViewConstraints()
+
+    setupActivityView()
     setupBorder()
   }
 
   // MARK: Subviews
+
+  private func setupActivityView() {
+    addSubview(activityView)
+
+    let constraints = [
+      activityView.centerXAnchor.constraint(equalTo: centerXAnchor),
+      activityView.centerYAnchor.constraint(equalTo: centerYAnchor),
+    ]
+    constraints.forEach { $0.priority = (.defaultLow - 1) }
+
+    NSLayoutConstraint.activate(constraints)
+  }
 
   private func setupWebView() {
     let preferences = WKPreferences()
@@ -168,7 +189,7 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
     )
   }
 
-  private func setupConstraints() {
+  private func setupWebViewConstraints() {
     webView.translatesAutoresizingMaskIntoConstraints = false
 
     let webViewConstraints = [
@@ -263,6 +284,8 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
   }
 
   public func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+    activityView.stopAnimating()
+
     let tokenAndMoney: String
 
     switch widgetMode {


### PR DESCRIPTION
Usually, the web view should be providing its own loading indicator. That may take a while to show up, however. We can put our own native UIActivityIndicator on top. This means there is at least something to see while the rest of the web content is loaded.

https://user-images.githubusercontent.com/790199/117607033-8046ba00-b19e-11eb-877a-fd8d865b3175.mp4

