### PR TITLE
Update URLs for widget bootstrap deployment

### DIFF
--- a/Sources/Afterpay/Model/Environment.swift
+++ b/Sources/Afterpay/Model/Environment.swift
@@ -18,7 +18,12 @@ import Foundation
   }
 
   var widgetBootstrapScriptURL: URL {
-    URL(string: "https://afterpay.github.io/sdk-example-server/widget-bootstrap.js")!
+    switch self {
+    case .sandbox:
+      return URL(string: "https://afterpay.github.io/sdk-example-server/widget-bootstrap.js")!
+    case .production:
+      return URL(string: "https://static.afterpay.com/mobile-sdk/bootstrap/widget-bootstrap.js")!
+    }
   }
 
   var afterpayJsURL: String {


### PR DESCRIPTION
Adds the new URLs for the widget bootstrap deployment. 

I've kept the sandbox URL as the old one, rather than using `static.sandbox.afterpay.com`. This way, we can still control it.