### PR TITLE
Fix two linter warnings

### DIFF
--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -223,8 +223,7 @@ final class CheckoutV2ViewController:
     let checkout = CheckoutV2(token: token, configuration: configuration, options: options)
     // swiftlint:disable:next force_try
     let json = String(data: try! encoder.encode(checkout), encoding: .utf8)!
-    let javaScript = "openCheckout('\(json)');"
-    bootstrapWebView.evaluateJavaScript(javaScript)
+    bootstrapWebView.evaluateJavaScript("openCheckout('\(json)');")
   }
 
   private func handleError(webView: WKWebView?, error: Error) {

--- a/Sources/Afterpay/Views/LinkTextView.swift
+++ b/Sources/Afterpay/Views/LinkTextView.swift
@@ -30,7 +30,6 @@ final class LinkTextView: UITextView, UITextViewDelegate {
   // Unfortunately implementing UITextViewDelegate textView(_:shouldInteractWith:in:interaction:)
   // for NSTextAttachments isn't enough to prevent drag and drop being initiated
   override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-    // TODO: Test if this is necessary when language is set to an RTL language
     let isRightToLeft = traitCollection.layoutDirection == .rightToLeft
     let direction: UITextLayoutDirection = isRightToLeft ? .right : .left
 


### PR DESCRIPTION
## Summary of Changes

- Make `CheckoutV2ViewController` fit into 200 lines.
- Remove a TODO which does not need to be done
