### PR TITLE
Re-enable widget UI test with mock bootstrap

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		551BEDF825F9B95C00FDF9EE /* WidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDF725F9B95C00FDF9EE /* WidgetView.swift */; };
 		551BEDFC25F9C56600FDF9EE /* WidgetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BEDFB25F9C56600FDF9EE /* WidgetEvent.swift */; };
 		55432830263A61C4005512E4 /* CombineWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5543282F263A61C4005512E4 /* CombineWrapper.swift */; };
+		556DEBFB2653531F00BFC277 /* mock-widget-bootstrap.js in Resources */ = {isa = PBXBuildFile; fileRef = 556DEBF92653531000BFC277 /* mock-widget-bootstrap.js */; };
 		557511BB264259C30040CC51 /* CombineWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BA264259C30040CC51 /* CombineWrapperTests.swift */; };
 		557511BF2644CAA50040CC51 /* WKWebView+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */; };
 		557511C12644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */; };
@@ -87,6 +88,7 @@
 		551BEDF725F9B95C00FDF9EE /* WidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetView.swift; sourceTree = "<group>"; };
 		551BEDFB25F9C56600FDF9EE /* WidgetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEvent.swift; sourceTree = "<group>"; };
 		5543282F263A61C4005512E4 /* CombineWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineWrapper.swift; sourceTree = "<group>"; };
+		556DEBF92653531000BFC277 /* mock-widget-bootstrap.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "mock-widget-bootstrap.js"; sourceTree = "<group>"; };
 		557511BA264259C30040CC51 /* CombineWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineWrapperTests.swift; sourceTree = "<group>"; };
 		557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Cache.swift"; sourceTree = "<group>"; };
 		557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebViewConfiguration+UserAgent.swift"; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 		665FC5782488766C00A5A93E /* AfterpayTests */ = {
 			isa = PBXGroup;
 			children = (
+				556DEBF92653531000BFC277 /* mock-widget-bootstrap.js */,
 				6635B95E24CAA9F000EBB3A6 /* ConfigurationTests.swift */,
 				66C3F7FA25397A810086DD0A /* CurrencyFormatterTests.swift */,
 				551BEDF025F98FA800FDF9EE /* FeaturesTests.swift */,
@@ -470,6 +473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5519DFAC261D38A8000628FF /* README.md in Resources */,
+				556DEBFB2653531F00BFC277 /* mock-widget-bootstrap.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AfterpayTests/mock-widget-bootstrap.js
+++ b/AfterpayTests/mock-widget-bootstrap.js
@@ -1,0 +1,15 @@
+document.getElementById("afterpay-widget-container").innerHTML = "Mock bootstrap loaded…"
+
+function createAfterpayWidget(token, amount, locale, style) {
+  document.getElementById("afterpay-widget-container").innerHTML = JSON.stringify({
+    "token": token,
+    "amount": amount,
+    "locale": locale,
+    "style": style
+  });
+}
+
+function updateAmount(amount) {
+  document.getElementById("afterpay-widget-container").innerHTML =
+    "Update called with " + JSON.stringify(amount);
+}

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -39,6 +39,8 @@ final class ExampleUITests: XCTestCase {
   func testTokenlessWidgetAppears() throws {
     app.buttons["Tokenless…"].tap()
 
+    _ = app.webViews.staticTexts.firstMatch.waitForExistence(timeout: 10)
+
     let webViewText = app.webViews.staticTexts.firstMatch
 
     XCTAssertTrue(webViewText.label.contains(#"token":null"#))

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Afterpay. All rights reserved.
 //
 
+import Afterpay
 import XCTest
 
 final class ExampleUITests: XCTestCase {
@@ -13,7 +14,7 @@ final class ExampleUITests: XCTestCase {
   private let app = XCUIApplication()
 
   override func setUp() {
-    app.launchArguments = ["-com.afterpay.widget-enabled", "YES"]
+    app.launchArguments = ["-com.afterpay.mock-widget-bootstrap", "YES"]
     app.launch()
   }
 
@@ -35,14 +36,21 @@ final class ExampleUITests: XCTestCase {
     app.buttons["Yes"].tap()
   }
 
-  // Skipped while we come up with a better way to end to end test the bootstrap 
-  func skip_testTokenlessWidgetAppears() throws {
+  func testTokenlessWidgetAppears() throws {
     app.buttons["Tokenless…"].tap()
 
-    XCTAssertTrue(app.staticTexts["Due today"].waitForExistence(timeout: 10))
-    XCTAssertTrue(app.staticTexts["Today"].waitForExistence(timeout: 0.5))
-    XCTAssertTrue(app.staticTexts["In 2 weeks"].waitForExistence(timeout: 0.5))
-    XCTAssertTrue(app.staticTexts["In 4 weeks"].waitForExistence(timeout: 0.5))
+    let webViewText = app.webViews.staticTexts.firstMatch
+
+    XCTAssertTrue(webViewText.label.contains(#"token":null"#))
+    XCTAssertTrue(webViewText.label.contains(#"amount":"200.00"#))
+    XCTAssertTrue(webViewText.label.contains(#"currency":"AUD"#))
+
+    let textField = app.textFields.firstMatch
+    textField.tap()
+    textField.typeText("444")
+    app.buttons["Update"].tap()
+
+    XCTAssertTrue(webViewText.label.contains(#"{"amount":"444","currency":"AUD"}"#))
   }
 
 }

--- a/Sources/Afterpay/Features.swift
+++ b/Sources/Afterpay/Features.swift
@@ -27,4 +27,9 @@ import Foundation
 ///   Overriding UserDefaults for improved productivity
 public struct AfterpayFeatures {
 
+  /// Are we using the real widget bootstrap, or a mock one? The mock widget bootstrap is used for end to end testing.
+  static var mockWidgetBootstrap: Bool {
+    UserDefaults.standard.bool(forKey: "com.afterpay.mock-widget-bootstrap")
+  }
+
 }

--- a/Sources/Afterpay/Model/Environment.swift
+++ b/Sources/Afterpay/Model/Environment.swift
@@ -44,14 +44,24 @@ import Foundation
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
         <script src="\(afterpayJsURL)"></script>
-        <script src="\(widgetBootstrapScriptURL.absoluteString)"></script>
 
+        \(bootstrapScript)
       </head>
       <body>
         <div id="afterpay-widget-container" style="margin: 16px 0px"></div>
       </body>
     </html>
     """
+  }
+
+  private var bootstrapScript: String {
+    if AfterpayFeatures.mockWidgetBootstrap {
+      let realUrl = Bundle(for: WidgetView.self).url(forResource: "mock-widget-bootstrap", withExtension: "js")!
+      let script = try? String(contentsOf: realUrl)
+      return #"<script>\#(script ?? "")</script>"#
+    }
+
+    return #"<script src="\#(widgetBootstrapScriptURL.absoluteString)"></script>"#
   }
 
 }

--- a/Sources/Afterpay/Widget/WidgetView.swift
+++ b/Sources/Afterpay/Widget/WidgetView.swift
@@ -296,7 +296,10 @@ public final class WidgetView: UIView, WKNavigationDelegate, WKScriptMessageHand
 
     webView.evaluateJavaScript(
       #"createAfterpayWidget(\#(tokenAndMoney), "\#(locale)", \#(styleParameter));"#
-    )
+    ) { _, error in
+      guard let error = error else { return }
+      getWidgetHandler()?.onFailure(error: error)
+    }
   }
 
   public func webView(


### PR DESCRIPTION
## Summary of Changes

Previously, we had disabled the widget UI test. Now, instead of loading the real widget via the real bootstrap, we use a mock bootstrap.

The mock bootstrap works by replacing the `afterpay-widget-container` with a message. It does this in response to the iOS WidgetView calling its methods. We can test that message.
