### PR TITLE
Disable animations for UI tests

### DIFF
--- a/Example/Example/SceneDelegate.swift
+++ b/Example/Example/SceneDelegate.swift
@@ -20,6 +20,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, WindowHolder {
     options connectionOptions: UIScene.ConnectionOptions
   ) {
     install(window: UIWindow(windowScene: scene as! UIWindowScene))
+
+    #if DEBUG
+    if CommandLine.arguments.contains("-disableAnimations") {
+      window?.layer.speed = 4.0
+    }
+    #endif
+
   }
 
 }

--- a/Example/ExampleUITests/ExampleUITests.swift
+++ b/Example/ExampleUITests/ExampleUITests.swift
@@ -14,8 +14,11 @@ final class ExampleUITests: XCTestCase {
   private let app = XCUIApplication()
 
   override func setUp() {
-    app.launchArguments = ["-com.afterpay.mock-widget-bootstrap", "YES"]
+    app.launchArguments.append(contentsOf: ["-com.afterpay.mock-widget-bootstrap", "YES"])
+    app.launchArguments.append("-disableAnimations")
     app.launch()
+
+    UIView.setAnimationsEnabled(false)
   }
 
   func testCheckoutShows() throws {
@@ -31,7 +34,7 @@ final class ExampleUITests: XCTestCase {
 
     app.swipeDown()
 
-    XCTAssertTrue(app.staticTexts["Are you sure you want to cancel the payment?"].waitForExistence(timeout: 0.5))
+    XCTAssertTrue(app.staticTexts["Are you sure you want to cancel the payment?"].waitForExistence(timeout: 3))
 
     app.buttons["Yes"].tap()
   }


### PR DESCRIPTION
With the launch argument `-disableAnimations`, we make the animations go 4 times faster. We don't actually disable them because that [can stuff up the timing of certain callbacks, etc.](https://mobile.twitter.com/steipete/status/1372460020730843136) 