### PR TITLE
Show cancel alert with `.alert` style on iPad

### DIFF
--- a/Sources/Afterpay/Views/Alerts.swift
+++ b/Sources/Afterpay/Views/Alerts.swift
@@ -38,7 +38,7 @@ enum Alerts {
     let actionSheet = UIAlertController(
       title: "Are you sure you want to cancel the payment?",
       message: nil,
-      preferredStyle: .actionSheet
+      preferredStyle: UIDevice.current.userInterfaceIdiom == .phone ? .actionSheet : .alert
     )
 
     let cancelHandler: (UIAlertAction) -> Void = { _ in cancel() }


### PR DESCRIPTION
Previously, we showed the 'are you sure you want to cancel the payment' alert with the preferred style of '.actionSheet'. This looks good on iPhone, but on iPad, it hits an assertion failure in UIKit. On iPad, an `.actionSheet` style needs a sourceView and sourceRect or a barButtonItem.

Such an alert style would look out of place, anyway, so we have changed the alert style to be `.alert` on iPad and `.actionSheet` on iPhone.

| iPhone  | iPad |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-08-20 at 07 19 09](https://user-images.githubusercontent.com/790199/130146385-11e8f2e1-c797-45c2-9392-7531f2569716.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-08-20 at 07 20 11](https://user-images.githubusercontent.com/790199/130146459-e9bf573d-8bb1-45fe-8b04-0f8a3ce828e7.png) |

resolves https://github.com/afterpay/sdk-ios/issues/171