### PR TITLE
Fix: pin dependency for cocoapods

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 env:
   afterpay-scheme: Afterpay
-  DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      destination: platform=iOS Simulator,name=iPhone 11,OS=14.0
+      destination: platform=iOS Simulator,name=iPhone 11,OS=14.5
       example-scheme: Example
       example-ui-test-scheme: ExampleUITests
       workspace: Afterpay.xcworkspace

--- a/Afterpay.podspec
+++ b/Afterpay.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |spec|
   spec.framework     = "UIKit"
 
   spec.dependency "Macaw", "0.9.7"
+  spec.dependency "SWXMLHash", "5.0.1"
 end

--- a/Configurations/Afterpay-Shared.xcconfig
+++ b/Configurations/Afterpay-Shared.xcconfig
@@ -169,4 +169,4 @@ TARGETED_DEVICE_FAMILY = 1,2
 // This setting defines the user-visible version of the project. The value corresponds to
 // the `CFBundleShortVersionString` key in your app's Info.plist.
 
-MARKETING_VERSION = 3.0.4
+MARKETING_VERSION = 3.0.5

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Add the Afterpay SDK as a [git submodule][git-submodule] by navigating to the ro
 ```
 git submodule add https://github.com/afterpay/sdk-ios.git Afterpay
 cd Afterpay
-git checkout 5
+git checkout 3.0.5
 ```
 
 #### Project / Workspace Integration

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is the recommended integration method.
 
 ```
 dependencies: [
-    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "3.0.4"))
+    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "3.0.5"))
 ]
 ```
 
@@ -109,7 +109,7 @@ Add the Afterpay SDK as a [git submodule][git-submodule] by navigating to the ro
 ```
 git submodule add https://github.com/afterpay/sdk-ios.git Afterpay
 cd Afterpay
-git checkout 3.0.4
+git checkout 5
 ```
 
 #### Project / Workspace Integration


### PR DESCRIPTION
## Summary of Changes

Explicitly define SWXMLHash as a dependency as CocoaPods was using the latest. The latest version (v6 - recently released) contains breaking changes. This change was cherry picked from feature/button branch. Documentation changed only for version bump.

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [ ] Tests are included.
- [x] Documentation is changed or added.
