### PR TITLE
Update GitHub Actions Xcode to 12.5.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 env:
   afterpay-scheme: Afterpay
-  DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
 
 on:
   push:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      destination: platform=iOS Simulator,name=iPhone 11,OS=14.0
+      destination: platform=iOS Simulator,name=iPhone 11,OS=14.5
       example-scheme: Example
       example-ui-test-scheme: ExampleUITests
       workspace: Afterpay.xcworkspace


### PR DESCRIPTION
GitHub Actions no longer supports Xcode 12.0. We will now use 12.5.1.

Available options at the time of writing are: 13.0 (beta), 13.0, 12.5.1, 12.5, 12.4, 11.7. We chose 12.5.1 because 13 has been having stability issues for many people.
