### PR TITLE
Publicise model types

### DIFF
--- a/Configurations/Afterpay-Shared.xcconfig
+++ b/Configurations/Afterpay-Shared.xcconfig
@@ -169,4 +169,4 @@ TARGETED_DEVICE_FAMILY = 1,2
 // This setting defines the user-visible version of the project. The value corresponds to
 // the `CFBundleShortVersionString` key in your app's Info.plist.
 
-MARKETING_VERSION = 3.0.5
+MARKETING_VERSION = 3.0.6

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is the recommended integration method.
 
 ```
 dependencies: [
-    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "3.0.5"))
+    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "3.0.6"))
 ]
 ```
 
@@ -109,7 +109,7 @@ Add the Afterpay SDK as a [git submodule][git-submodule] by navigating to the ro
 ```
 git submodule add https://github.com/afterpay/sdk-ios.git Afterpay
 cd Afterpay
-git checkout 3.0.5
+git checkout 3.0.6
 ```
 
 #### Project / Workspace Integration

--- a/Sources/Afterpay/Model/Money.swift
+++ b/Sources/Afterpay/Model/Money.swift
@@ -10,8 +10,8 @@ import Foundation
 
 public struct Money: Codable, Equatable {
 
-  var amount: String
-  var currency: String
+  public var amount: String
+  public var currency: String
 
   public init(amount: String, currency: String) {
     self.amount = amount

--- a/Sources/Afterpay/Model/ShippingAddress.swift
+++ b/Sources/Afterpay/Model/ShippingAddress.swift
@@ -10,10 +10,10 @@ import Foundation
 
 public struct ShippingAddress: Decodable {
 
-  var countryCode: String?
-  var postcode: String?
-  var phoneNumber: String?
-  var state: String?
-  var suburb: String?
+  public var countryCode: String?
+  public var postcode: String?
+  public var phoneNumber: String?
+  public var state: String?
+  public var suburb: String?
 
 }

--- a/Sources/Afterpay/Model/ShippingOption.swift
+++ b/Sources/Afterpay/Model/ShippingOption.swift
@@ -10,12 +10,12 @@ import Foundation
 
 public struct ShippingOption: Codable {
 
-  var id: String
-  var name: String
-  var description: String
-  var shippingAmount: Money
-  var orderAmount: Money
-  var taxAmount: Money?
+  public var id: String
+  public var name: String
+  public var description: String
+  public var shippingAmount: Money
+  public var orderAmount: Money
+  public var taxAmount: Money?
 
   public init(
     id: String,


### PR DESCRIPTION
Previously, some model types were internal, but returned by public call backs. This meant our API consumers couldn't see inside the values the callbacks were giving them. Marking them as `public` allows them to.

## Summary of Changes

- Marks `ShippingAddress`, `ShippingOption` and `Money` properties as `public`.

Fixes #183