### PR TITLE
Add missing fields to `ShippingAddress`

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ final class CheckoutHandler: CheckoutV2Handler {
     // Load the token passing the result to completion
   }
 
-  func shippingAddressDidChange(address: Address, completion: @escaping ShippingOptionsCompletion) {
+  func shippingAddressDidChange(address: ShippingAddress, completion: @escaping ShippingOptionsCompletion) {
     // Use the address to form a shipping options result and pass to completion
   }
 

--- a/Sources/Afterpay/Model/ShippingAddress.swift
+++ b/Sources/Afterpay/Model/ShippingAddress.swift
@@ -10,6 +10,9 @@ import Foundation
 
 public struct ShippingAddress: Decodable {
 
+  public var name: String?
+  public var address1: String?
+  public var address2: String?
   public var countryCode: String?
   public var postcode: String?
   public var phoneNumber: String?


### PR DESCRIPTION
There are a few missing fields in `ShippingAddress`. It seems that `name`, `address1` and `address2` are returned by the API, but are not in our model type, so we don't send them along to the API consumer.

Let's add them.

## Summary of Changes

- Add new fields to the `ShippingAddress` type.

## Items of Note

These fields seem to be [undocumented](https://developers.afterpay.com/afterpay-online/reference/integrated-shipping-2).

Fixes #186
