### PR TITLE
add closure for updating shipping option once selected

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		157E88D125CBCA49007E54C4 /* Result+Fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157E88D025CBCA49007E54C4 /* Result+Fold.swift */; };
 		15EC67D225E6217F007DFEA8 /* OSLog+Afterpay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EC67D125E6217F007DFEA8 /* OSLog+Afterpay.swift */; };
 		15F7DDB725393BD30011EC25 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */; };
+		42927C39274209B600B26435 /* ShippingOptionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42927C38274209B600B26435 /* ShippingOptionUpdate.swift */; };
 		42DA4F9826E0740500204E75 /* IntroText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DA4F9726E0740500204E75 /* IntroText.swift */; };
 		550D48152625539900C0B0C6 /* WidgetStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550D48142625539900C0B0C6 /* WidgetStatusTests.swift */; };
 		550D481B26255D8600C0B0C6 /* WidgetEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550D481A26255D8600C0B0C6 /* WidgetEventTests.swift */; };
@@ -81,6 +82,7 @@
 		15EC67D125E6217F007DFEA8 /* OSLog+Afterpay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSLog+Afterpay.swift"; sourceTree = "<group>"; };
 		15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		15FAC56625DCCEDF00DE7792 /* Afterpay.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Afterpay.podspec; sourceTree = "<group>"; };
+		42927C38274209B600B26435 /* ShippingOptionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingOptionUpdate.swift; sourceTree = "<group>"; };
 		42DA4F9726E0740500204E75 /* IntroText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroText.swift; sourceTree = "<group>"; };
 		550D48142625539900C0B0C6 /* WidgetStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStatusTests.swift; sourceTree = "<group>"; };
 		550D481A26255D8600C0B0C6 /* WidgetEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEventTests.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 				661D431E257DC86C00ACCDE1 /* ShippingAddress.swift */,
 				661D4322257DF1CB00ACCDE1 /* ShippingOption.swift */,
 				157C65AE25D23E8F00115149 /* Version.swift */,
+				42927C38274209B600B26435 /* ShippingOptionUpdate.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -551,6 +554,7 @@
 				66169312257A06B200DF6CF4 /* CheckoutV2Message.swift in Sources */,
 				666818202591CB9800A2003E /* Alerts.swift in Sources */,
 				6689536C24C96CB5005090B4 /* Configuration.swift in Sources */,
+				42927C39274209B600B26435 /* ShippingOptionUpdate.swift in Sources */,
 				15F7DDB725393BD30011EC25 /* CurrencyFormatter.swift in Sources */,
 				66DAAC8B24E0CF0100127460 /* PriceBreakdown.swift in Sources */,
 				551BEDFC25F9C56600FDF9EE /* WidgetEvent.swift in Sources */,

--- a/Example/Example/Purchase/CheckoutHandler.swift
+++ b/Example/Example/Purchase/CheckoutHandler.swift
@@ -10,19 +10,22 @@ import Afterpay
 import Foundation
 
 final class CheckoutHandler: CheckoutV2Handler {
-
   private let didCommenceCheckoutClosure: () -> Void
   private let onShippingAddressDidChangeClosure: (ShippingAddress) -> Void
+  private let onShippingOptionClosure: (ShippingOption) -> Void
 
   private var checkoutTokenResultCompletion: TokenResultCompletion?
   private var shippingOptionsCompletion: ShippingOptionsCompletion?
+  private var shippingOptionCompletion: ShippingOptionCompletion?
 
   init(
     didCommenceCheckout: @escaping () -> Void,
-    onShippingAddressDidChange: @escaping (ShippingAddress) -> Void
+    onShippingAddressDidChange: @escaping (ShippingAddress) -> Void,
+    onShippingOptionChange: @escaping (ShippingOption) -> Void
   ) {
     didCommenceCheckoutClosure = didCommenceCheckout
     onShippingAddressDidChangeClosure = onShippingAddressDidChange
+    onShippingOptionClosure = onShippingOptionChange
   }
 
   func didCommenceCheckout(completion: @escaping TokenResultCompletion) {
@@ -48,6 +51,14 @@ final class CheckoutHandler: CheckoutV2Handler {
     shippingOptionsCompletion = nil
   }
 
-  func shippingOptionDidChange(shippingOption: ShippingOption) {}
+  func shippingOptionDidChange(shippingOption: ShippingOption, completion: @escaping ShippingOptionCompletion) {
+    shippingOptionCompletion = completion
+    onShippingOptionClosure(shippingOption)
+  }
+
+  func provideShippingOptionResult(result shippingOptionResult: ShippingOptionUpdateResult) {
+    shippingOptionCompletion?(shippingOptionResult)
+    shippingOptionCompletion = nil
+  }
 
 }

--- a/Example/Example/Purchase/CheckoutHandler.swift
+++ b/Example/Example/Purchase/CheckoutHandler.swift
@@ -12,7 +12,7 @@ import Foundation
 final class CheckoutHandler: CheckoutV2Handler {
   private let didCommenceCheckoutClosure: () -> Void
   private let onShippingAddressDidChangeClosure: (ShippingAddress) -> Void
-  private let onShippingOptionClosure: (ShippingOption) -> Void
+  private let onShippingOptionDidChangeClosure: (ShippingOption) -> Void
 
   private var checkoutTokenResultCompletion: TokenResultCompletion?
   private var shippingOptionsCompletion: ShippingOptionsCompletion?
@@ -21,11 +21,11 @@ final class CheckoutHandler: CheckoutV2Handler {
   init(
     didCommenceCheckout: @escaping () -> Void,
     onShippingAddressDidChange: @escaping (ShippingAddress) -> Void,
-    onShippingOptionChange: @escaping (ShippingOption) -> Void
+    onShippingOptionDidChange: @escaping (ShippingOption) -> Void
   ) {
     didCommenceCheckoutClosure = didCommenceCheckout
     onShippingAddressDidChangeClosure = onShippingAddressDidChange
-    onShippingOptionClosure = onShippingOptionChange
+    onShippingOptionDidChangeClosure = onShippingOptionDidChange
   }
 
   func didCommenceCheckout(completion: @escaping TokenResultCompletion) {
@@ -53,7 +53,7 @@ final class CheckoutHandler: CheckoutV2Handler {
 
   func shippingOptionDidChange(shippingOption: ShippingOption, completion: @escaping ShippingOptionCompletion) {
     shippingOptionCompletion = completion
-    onShippingOptionClosure(shippingOption)
+    onShippingOptionDidChangeClosure(shippingOption)
   }
 
   func provideShippingOptionResult(result shippingOptionResult: ShippingOptionUpdateResult) {

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -37,7 +37,8 @@ final class PurchaseFlowController: UIViewController {
 
     checkoutHandler = CheckoutHandler(
       didCommenceCheckout: logicController.loadCheckoutToken,
-      onShippingAddressDidChange: logicController.selectAddress
+      onShippingAddressDidChange: logicController.selectAddress,
+      onShippingOptionChange: logicController.selectShipping
     )
 
     Afterpay.setCheckoutV2Handler(checkoutHandler)
@@ -116,6 +117,9 @@ final class PurchaseFlowController: UIViewController {
 
     case .provideShippingOptionsResult(let shippingOptionsResult):
       checkoutHandler.provideShippingOptionsResult(result: shippingOptionsResult)
+
+    case .provideShippingOptionResult(let shippingOptionResult):
+      checkoutHandler.provideShippingOptionResult(result: shippingOptionResult)
 
     case .showAlertForErrorMessage(let errorMessage):
       let alert = AlertFactory.alert(for: errorMessage)

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -38,7 +38,7 @@ final class PurchaseFlowController: UIViewController {
     checkoutHandler = CheckoutHandler(
       didCommenceCheckout: logicController.loadCheckoutToken,
       onShippingAddressDidChange: logicController.selectAddress,
-      onShippingOptionChange: logicController.selectShipping
+      onShippingOptionDidChange: logicController.selectShipping
     )
 
     Afterpay.setCheckoutV2Handler(checkoutHandler)

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -165,7 +165,8 @@ final class PurchaseLogicController {
   }
 
   func selectShipping(shippingOption: ShippingOption) {
-    if shippingOption.id == "standard" {
+    switch shippingOption.id {
+    case "standard":
       let updatedShippingOption = ShippingOptionUpdate(
         id: shippingOption.id,
         shippingAmount: Money(amount: "0.00", currency: currencyCode),
@@ -175,6 +176,8 @@ final class PurchaseLogicController {
 
       let result: ShippingOptionUpdateResult = .success(updatedShippingOption)
       commandHandler(.provideShippingOptionResult(result))
+    default:
+      commandHandler(.provideShippingOptionResult(nil))
     }
   }
 

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -165,8 +165,7 @@ final class PurchaseLogicController {
   }
 
   func selectShipping(shippingOption: ShippingOption) {
-    switch shippingOption.id {
-    case "standard":
+    if shippingOption.id == "standard" {
       let updatedShippingOption = ShippingOptionUpdate(
         id: shippingOption.id,
         shippingAmount: Money(amount: "0.00", currency: currencyCode),
@@ -176,7 +175,7 @@ final class PurchaseLogicController {
 
       let result: ShippingOptionUpdateResult = .success(updatedShippingOption)
       commandHandler(.provideShippingOptionResult(result))
-    default:
+    } else {
       commandHandler(.provideShippingOptionResult(nil))
     }
   }

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -20,6 +20,7 @@ final class PurchaseLogicController {
     case showAfterpayCheckoutV2(CheckoutV2Options)
     case provideCheckoutTokenResult(TokenResult)
     case provideShippingOptionsResult(ShippingOptionsResult)
+    case provideShippingOptionResult(ShippingOptionUpdateResult)
 
     case showAlertForErrorMessage(String)
     case showSuccessWithMessage(String, Token)
@@ -49,7 +50,8 @@ final class PurchaseLogicController {
   private var checkoutV2Options = CheckoutV2Options(
     pickup: false,
     buyNow: false,
-    shippingOptionRequired: true
+    shippingOptionRequired: true,
+    enableSingleShippingOptionUpdate: true
   )
 
   private var expressCheckout: Bool = true
@@ -145,19 +147,35 @@ final class PurchaseLogicController {
         name: "Standard",
         description: "3 - 5 days",
         shippingAmount: Money(amount: "0.00", currency: currencyCode),
-        orderAmount: Money(amount: "50.00", currency: currencyCode)
+        orderAmount: Money(amount: "50.00", currency: currencyCode),
+        taxAmount: Money(amount: "2.00", currency: currencyCode)
       ),
       ShippingOption(
         id: "priority",
         name: "Priority",
         description: "Next business day",
         shippingAmount: Money(amount: "10.00", currency: currencyCode),
-        orderAmount: Money(amount: "60.00", currency: currencyCode)
+        orderAmount: Money(amount: "60.00", currency: currencyCode),
+        taxAmount: Money(amount: "2.00", currency: currencyCode)
       ),
     ]
 
     let result: ShippingOptionsResult = .success(shippingOptions)
     commandHandler(.provideShippingOptionsResult(result))
+  }
+
+  func selectShipping(shippingOption: ShippingOption) {
+    if shippingOption.id == "standard" {
+      let updatedShippingOption = ShippingOptionUpdate(
+        id: shippingOption.id,
+        shippingAmount: Money(amount: "0.00", currency: currencyCode),
+        orderAmount: Money(amount: "42.00", currency: currencyCode),
+        taxAmount: Money(amount: "8.00", currency: currencyCode)
+      )
+
+      let result: ShippingOptionUpdateResult = .success(updatedShippingOption)
+      commandHandler(.provideShippingOptionResult(result))
+    }
   }
 
   func success(with token: String) {

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Afterpay.presentCheckoutV2Modally(
   shippingAddressDidChange: { address, completion in
     // Use the address to form a shipping options result and pass to completion
   },
-  shippingOptionDidChange: { shippingOption in
+  shippingOptionDidChange: { shippingOption, completion in
     // Optionally update your application model with the selected shipping option
   },
   completion: { result in
@@ -516,7 +516,7 @@ final class CheckoutHandler: CheckoutV2Handler {
     // Use the address to form a shipping options result and pass to completion
   }
 
-  func shippingOptionDidChange(shippingOption: ShippingOption) {
+  func shippingOptionDidChange(shippingOption: ShippingOption, completion: @escaping ShippingOptionCompletion) {
     // Optionally update your application model with the selected shipping option
   }
 }

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -123,7 +123,7 @@ public typealias ShippingAddressDidChangeClosure = (
   _ completion: @escaping ShippingOptionsCompletion
 ) -> Void
 
-public typealias ShippingOptionsDidChangeClosure = (
+public typealias ShippingOptionDidChangeClosure = (
   _ shippingOption: ShippingOption,
   _ complete: @escaping ShippingOptionCompletion
 ) -> Void
@@ -153,7 +153,7 @@ public func presentCheckoutV2Modally(
   options: CheckoutV2Options = .init(),
   didCommenceCheckout: DidCommenceCheckoutClosure? = nil,
   shippingAddressDidChange: ShippingAddressDidChangeClosure? = nil,
-  shippingOptionDidChange: ShippingOptionsDidChangeClosure? = nil,
+  shippingOptionDidChange: ShippingOptionDidChangeClosure? = nil,
   completion: @escaping (_ result: CheckoutResult) -> Void
 ) {
   guard let configuration = getConfiguration() else {

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -108,7 +108,7 @@ public typealias DidCommenceCheckoutClosure = (
 
 public typealias ShippingOptionsResult = Result<[ShippingOption], ShippingOptionsError>
 
-public typealias ShippingOptionUpdateResult = Result<ShippingOptionUpdate, ShippingOptionsError>
+public typealias ShippingOptionUpdateResult = Result<ShippingOptionUpdate, ShippingOptionsError>?
 
 public typealias ShippingOptionsCompletion = (
   _ shippingOptionsResult: ShippingOptionsResult

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -62,10 +62,20 @@ public struct CheckoutV2Options: Equatable {
   /// the user from selecting shipping options within checkout.
   public var shippingOptionRequired: Bool?
 
-  public init(pickup: Bool? = nil, buyNow: Bool? = nil, shippingOptionRequired: Bool? = nil) {
+  /// Setting `checkoutRedesignForced` to `true` when working with an express order will
+  /// force the redesigned checkout
+  internal var checkoutRedesignForced: Bool?
+
+  public init(
+    pickup: Bool? = nil,
+    buyNow: Bool? = nil,
+    shippingOptionRequired: Bool? = nil,
+    enableSingleShippingOptionUpdate: Bool? = nil
+  ) {
     self.pickup = pickup
     self.buyNow = buyNow
     self.shippingOptionRequired = shippingOptionRequired
+    self.checkoutRedesignForced = enableSingleShippingOptionUpdate
   }
 }
 
@@ -98,8 +108,14 @@ public typealias DidCommenceCheckoutClosure = (
 
 public typealias ShippingOptionsResult = Result<[ShippingOption], ShippingOptionsError>
 
+public typealias ShippingOptionUpdateResult = Result<ShippingOptionUpdate, ShippingOptionsError>
+
 public typealias ShippingOptionsCompletion = (
   _ shippingOptionsResult: ShippingOptionsResult
+) -> Void
+
+public typealias ShippingOptionCompletion = (
+  _ shippingOptionsResult: ShippingOptionUpdateResult
 ) -> Void
 
 public typealias ShippingAddressDidChangeClosure = (
@@ -107,7 +123,10 @@ public typealias ShippingAddressDidChangeClosure = (
   _ completion: @escaping ShippingOptionsCompletion
 ) -> Void
 
-public typealias ShippingOptionsDidChangeClosure = (_ shippingOption: ShippingOption) -> Void
+public typealias ShippingOptionsDidChangeClosure = (
+  _ shippingOption: ShippingOption,
+  _ complete: @escaping ShippingOptionCompletion
+) -> Void
 
 /// Present Afterpay Checkout modally over the specified view controller. This method calls the
 /// passed closures to facilitate loading the checkoutURL on demand falling back to the
@@ -190,7 +209,7 @@ public protocol CheckoutV2Handler: AnyObject {
   /// Called after the user selects one of the shipping options provided by the `completion` of
   /// `shippingAddressDidChange`.
   /// - Parameter shippingOption: The selected shipping option.
-  func shippingOptionDidChange(shippingOption: ShippingOption)
+  func shippingOptionDidChange(shippingOption: ShippingOption, completion: @escaping ShippingOptionCompletion)
 }
 
 private weak var checkoutV2Handler: CheckoutV2Handler?

--- a/Sources/Afterpay/Checkout/CheckoutV2.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2.swift
@@ -17,6 +17,7 @@ struct CheckoutV2: Encodable {
   var pickup: Bool?
   var buyNow: Bool?
   var shippingOptionRequired: Bool?
+  var checkoutRedesignForced: Bool?
 
   init(token: Token, configuration: Configuration, options: CheckoutV2Options) {
     self.token = token
@@ -26,5 +27,6 @@ struct CheckoutV2: Encodable {
     self.pickup = options.pickup
     self.buyNow = options.buyNow
     self.shippingOptionRequired = options.shippingOptionRequired
+    self.checkoutRedesignForced = options.checkoutRedesignForced
   }
 }

--- a/Sources/Afterpay/Checkout/CheckoutV2Message.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2Message.swift
@@ -17,6 +17,7 @@ struct CheckoutV2Message: Codable {
     case address(ShippingAddress)
     case errorMessage(String)
     case shippingOption(ShippingOption)
+    case shippingOptionUpdate(ShippingOptionUpdate)
     case shippingOptions([ShippingOption])
   }
 
@@ -76,6 +77,10 @@ struct CheckoutV2Message: Codable {
     switch payload {
     case .shippingOptions(let shippingOptions):
       try container.encode(shippingOptions, forKey: .payload)
+    case .shippingOption(let shippingOption):
+      try container.encode(shippingOption, forKey: .payload)
+    case .shippingOptionUpdate(let shippingOptionUpdate):
+      try container.encode(shippingOptionUpdate, forKey: .payload)
     case .errorMessage(let errorMessage):
       // This is asymmetric with decode, errors are encoded as their own key/value pair when sent
       // not as the payload

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -28,7 +28,7 @@ final class CheckoutV2ViewController:
 
   private let didCommenceCheckoutClosure: DidCommenceCheckoutClosure?
   private let shippingAddressDidChangeClosure: ShippingAddressDidChangeClosure?
-  private let shippingOptionDidChangeClosure: ShippingOptionsDidChangeClosure?
+  private let shippingOptionDidChangeClosure: ShippingOptionDidChangeClosure?
   private let completion: (_ result: CheckoutResult) -> Void
 
   private var didCommenceCheckout: DidCommenceCheckoutClosure? {
@@ -39,7 +39,7 @@ final class CheckoutV2ViewController:
     shippingAddressDidChangeClosure ?? getCheckoutV2Handler()?.shippingAddressDidChange
   }
 
-  private var shippingOptionDidChange: ShippingOptionsDidChangeClosure? {
+  private var shippingOptionDidChange: ShippingOptionDidChangeClosure? {
     shippingOptionDidChangeClosure ?? getCheckoutV2Handler()?.shippingOptionDidChange
   }
 
@@ -60,7 +60,7 @@ final class CheckoutV2ViewController:
     options: CheckoutV2Options,
     didCommenceCheckout: DidCommenceCheckoutClosure?,
     shippingAddressDidChange: ShippingAddressDidChangeClosure?,
-    shippingOptionDidChange: ShippingOptionsDidChangeClosure?,
+    shippingOptionDidChange: ShippingOptionDidChangeClosure?,
     completion: @escaping (_ result: CheckoutResult) -> Void
   ) {
     self.configuration = configuration

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -329,11 +329,12 @@ final class CheckoutV2ViewController:
       case .shippingOption(let shippingOption):
         shippingOptionDidChange?(shippingOption) { updatedShippingOption in
           let requestId = message.requestId
-          let responseMessage = updatedShippingOption.fold(
+
+          let responseMessage = updatedShippingOption?.fold(
             successTransform: { Message(requestId: requestId, payload: .shippingOptionUpdate($0)) },
             errorTransform: { Message(requestId: requestId, payload: .errorMessage($0.rawValue)) }
           )
-          postMessage(responseMessage)
+          postMessage(responseMessage ?? Message(requestId: requestId, payload: nil))
         }
       case .shippingOptions:
         break

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -11,7 +11,7 @@ import os.log
 import UIKit
 import WebKit
 
-// swiftlint:disable:next colon
+// swiftlint:disable:next colon type_body_length
 final class CheckoutV2ViewController:
   UIViewController,
   UIAdaptivePresentationControllerDelegate,

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -327,8 +327,17 @@ final class CheckoutV2ViewController:
         // Error messages raised in the webview are logged when in Debug for ease of debugging
         os_log("%@", log: .checkout, type: .debug, errorMessage)
       case .shippingOption(let shippingOption):
-        shippingOptionDidChange?(shippingOption)
+        shippingOptionDidChange?(shippingOption) { updatedShippingOption in
+          let requestId = message.requestId
+          let responseMessage = updatedShippingOption.fold(
+            successTransform: { Message(requestId: requestId, payload: .shippingOptionUpdate($0)) },
+            errorTransform: { Message(requestId: requestId, payload: .errorMessage($0.rawValue)) }
+          )
+          postMessage(responseMessage)
+        }
       case .shippingOptions:
+        break
+      case .shippingOptionUpdate:
         break
       }
     } else if let completion = completion {

--- a/Sources/Afterpay/Model/ShippingOptionUpdate.swift
+++ b/Sources/Afterpay/Model/ShippingOptionUpdate.swift
@@ -1,0 +1,30 @@
+//
+//  ShippingOptionUpdate.swift
+//  Afterpay
+//
+//  Created by Scott Antonac on 15/11/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+public struct ShippingOptionUpdate: Codable {
+
+  public var id: String
+  public var shippingAmount: Money
+  public var orderAmount: Money
+  public var taxAmount: Money?
+
+  public init(
+    id: String,
+    shippingAmount: Money,
+    orderAmount: Money,
+    taxAmount: Money? = nil
+  ) {
+    self.id = id
+    self.shippingAmount = shippingAmount
+    self.orderAmount = orderAmount
+    self.taxAmount = taxAmount
+  }
+
+}


### PR DESCRIPTION
This PR aims to allow the updating of a single shipping option once it has been selected (for instance updating the tax amount)

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Add a new param to `CheckoutV2Options`: `enableSingleShippingOptionUpdate`. This will need to be set to true to use this feature.
- Add functionality to example app
- Add a new model class: `ShippingOptionUpdate` that only takes `id` and `Money` amounts
- post message to checkout as closure to update shipping option
- send back empty payload if updated shipping option is `nil`

## Notes
This PR contains the following breaking changes
- public type alias `ShippingOptionsDidChangeClosure` changes to `ShippingOptionDidChangeClosure` for clarity
- public protocol `CheckoutV2Handler`'s method `shippingOptionDidChange` now takes a second parameter `completion` of type `ShippingOptionCompletion`