### PR TITLE
remove multiple codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @huwr @adamjcampbell @Rypac @k-obrien @nesevis @benfterpay @ScottAntonacAP
+*       @nesevis @benfterpay @ScottAntonacAP


### PR DESCRIPTION
removed huwr adamjcampbell rypac k-obrien from codeowners - leaving nesevis, benfterpay and ScottAntonacAP
brings this repo into line with sdk-android
