### PR TITLE
Feature/optional text

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		15EC67D225E6217F007DFEA8 /* OSLog+Afterpay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EC67D125E6217F007DFEA8 /* OSLog+Afterpay.swift */; };
 		15F7DDB725393BD30011EC25 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */; };
 		42927C39274209B600B26435 /* ShippingOptionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42927C38274209B600B26435 /* ShippingOptionUpdate.swift */; };
+		42D10C9F2761B1190028D6D9 /* OptionalText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D10C9E2761B1190028D6D9 /* OptionalText.swift */; };
 		42DA4F9826E0740500204E75 /* IntroText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DA4F9726E0740500204E75 /* IntroText.swift */; };
 		550D48152625539900C0B0C6 /* WidgetStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550D48142625539900C0B0C6 /* WidgetStatusTests.swift */; };
 		550D481B26255D8600C0B0C6 /* WidgetEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550D481A26255D8600C0B0C6 /* WidgetEventTests.swift */; };
@@ -83,6 +84,7 @@
 		15F7DDB625393BD30011EC25 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		15FAC56625DCCEDF00DE7792 /* Afterpay.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Afterpay.podspec; sourceTree = "<group>"; };
 		42927C38274209B600B26435 /* ShippingOptionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingOptionUpdate.swift; sourceTree = "<group>"; };
+		42D10C9E2761B1190028D6D9 /* OptionalText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalText.swift; sourceTree = "<group>"; };
 		42DA4F9726E0740500204E75 /* IntroText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroText.swift; sourceTree = "<group>"; };
 		550D48142625539900C0B0C6 /* WidgetStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStatusTests.swift; sourceTree = "<group>"; };
 		550D481A26255D8600C0B0C6 /* WidgetEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEventTests.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				557511C226489F090040CC51 /* SVG+Source.swift */,
 				6672982925357D80001D1C5A /* SVGConfiguration.swift */,
 				42DA4F9726E0740500204E75 /* IntroText.swift */,
+				42D10C9E2761B1190028D6D9 /* OptionalText.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -570,6 +573,7 @@
 				667AD3542497121200BF94E5 /* CheckoutWebViewController.swift in Sources */,
 				15EC67D225E6217F007DFEA8 /* OSLog+Afterpay.swift in Sources */,
 				551BEDEB25F983E200FDF9EE /* Features.swift in Sources */,
+				42D10C9F2761B1190028D6D9 /* OptionalText.swift in Sources */,
 				66F9767C2499A11A001D38FA /* Afterpay.swift in Sources */,
 				151A4FEB258C1F8A0046CEEE /* StaticContent.swift in Sources */,
 				66EE378724D39FC50029BF42 /* BadgeView.swift in Sources */,

--- a/Example/Example/Components/ComponentsViewController.swift
+++ b/Example/Example/Components/ComponentsViewController.swift
@@ -164,9 +164,16 @@ private final class ContentStackViewController: UIViewController, PriceBreakdown
     stack.addArrangedSubview(priceBreakdown1)
 
     let priceBreakdown2 = PriceBreakdownView()
-    priceBreakdown2.totalAmount = 3000
+    priceBreakdown2.totalAmount = 100
     priceBreakdown2.delegate = self
+    priceBreakdown2.showWithText = false
+    priceBreakdown2.showInterestFreeText = false
     stack.addArrangedSubview(priceBreakdown2)
+
+    let priceBreakdown3 = PriceBreakdownView()
+    priceBreakdown3.totalAmount = 3000
+    priceBreakdown3.delegate = self
+    stack.addArrangedSubview(priceBreakdown3)
 
     let stackConstraints = [
       stack.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),

--- a/README.md
+++ b/README.md
@@ -318,9 +318,9 @@ Given the above, the price breakdown text will be rendered `Make 4 interest-free
 ### Optional Text
 Setting `showInterestFreeText` and / or `showWithText` is optional and is of type `Bool`.
 
-Both default to true. This will show the text `pay in 4 interest-free payents of $#.## with`.
-Setting `showInterestFreeText` to false will remove "interest-free" from the sentence.
-Setting `showWithText` to false will remove the word "with" from the sentence.
+Both default to `true`. This will show the text `pay in 4 interest-free payments of $#.## with`.
+Setting `showInterestFreeText` to `false` will remove "interest-free" from the sentence.
+Setting `showWithText` to `false` will remove the word "with" from the sentence.
 
 ```swift
 let priceBreakdownView = PriceBreakdownView()

--- a/README.md
+++ b/README.md
@@ -313,7 +313,21 @@ let priceBreakdownView = PriceBreakdownView()
 priceBreakdownView.introText = AfterpayIntroText.makeTitle
 ```
 
-Given the above, the price breakdown text will be rendered `Make 4 interest-free payments of $##.##`
+Given the above, the price breakdown text will be rendered `Make 4 interest-free payments of $##.## with`
+
+### Optional Text
+Setting `showInterestFreeText` and / or `showWithText` is optional and is of type `Bool`.
+
+Both default to true. This will show the text `pay in 4 interest-free payents of $#.## with`.
+Setting `showInterestFreeText` to false will remove "interest-free" from the sentence.
+Setting `showWithText` to false will remove the word "with" from the sentence.
+
+```swift
+let priceBreakdownView = PriceBreakdownView()
+priceBreakdownView.showInterestFreeText = false
+```
+
+Given the above, the price breakdown text will be rendered `or 4 payments of $##.## with`
 
 ### Examples
 

--- a/Sources/Afterpay/Model/PriceBreakdown.swift
+++ b/Sources/Afterpay/Model/PriceBreakdown.swift
@@ -20,7 +20,9 @@ struct PriceBreakdown {
 
   init(
     totalAmount: Decimal,
-    introText: AfterpayIntroText = AfterpayIntroText.or
+    introText: AfterpayIntroText = AfterpayIntroText.or,
+    showInterestFreeText: Bool = true,
+    showWithText: Bool = true
   ) {
     let configuration = getConfiguration()
     let formatter = configuration
@@ -36,9 +38,20 @@ struct PriceBreakdown {
     let lessThanOrEqualToMaximum = totalAmount <= (configuration?.maximumAmount ?? .zero)
     let inRange = greaterThanZero && greaterThanOrEqualToMinimum && lessThanOrEqualToMaximum
 
+    let template: AfterpayOptionalText
+    if showInterestFreeText && showWithText {
+      template = .interestFreeAndWith
+    } else if showInterestFreeText {
+      template = .interestFree
+    } else if showWithText {
+      template = .with
+    } else {
+      template = .none
+    }
+
     if let formattedPayment = formattedPayment, inRange {
       badgePlacement = .end
-      string = String(format: Strings.fourPaymentsFormat, introText.rawValue, formattedPayment)
+      string = String(format: template.stringValue, introText.rawValue, formattedPayment)
         .trimmingCharacters(in: .whitespaces)
     } else if let formattedMinimum = formattedMinimum, let formattedMaximum = formattedMaximum {
       badgePlacement = .start

--- a/Sources/Afterpay/Resources/OptionalText.swift
+++ b/Sources/Afterpay/Resources/OptionalText.swift
@@ -1,0 +1,29 @@
+//
+//  OptionalText.swift
+//  Afterpay
+//
+//  Created by Scott Antonac on 9/12/21.
+//  Copyright © 2021 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+public enum AfterpayOptionalText {
+  case none
+  case interestFree
+  case with
+  case interestFreeAndWith
+
+  var stringValue: String {
+    switch self {
+    case .none:
+      return Strings.fourPaymentsFormatNoOptional
+    case .interestFree:
+      return Strings.fourPaymentsFormatInterest
+    case .with:
+      return Strings.fourPaymentsFormatWith
+    case .interestFreeAndWith:
+      return Strings.fourPaymentsFormatInterestAndWith
+    }
+  }
+}

--- a/Sources/Afterpay/Resources/Strings.swift
+++ b/Sources/Afterpay/Resources/Strings.swift
@@ -21,7 +21,10 @@ enum Strings {
 
   static let availableBetweenFormat = "available for orders between %@ - %@"
   static let availableUpToFormat = "available for orders up to %@"
-  static let fourPaymentsFormat = "%@ 4 interest-free payments of %@ with"
+  static let fourPaymentsFormatNoOptional = "%@ 4 payments of %@"
+  static let fourPaymentsFormatWith = "%@ 4 payments of %@ with"
+  static let fourPaymentsFormatInterest = "%@ 4 interest-free payments of %@"
+  static let fourPaymentsFormatInterestAndWith = "%@ 4 interest-free payments of %@ with"
 
   // MARK: - Accessible Strings
 

--- a/Sources/Afterpay/Views/PriceBreakdownView.swift
+++ b/Sources/Afterpay/Views/PriceBreakdownView.swift
@@ -42,6 +42,18 @@ public final class PriceBreakdownView: UIView {
     }
   }
 
+  public var showWithText: Bool = true {
+    didSet {
+      updateAttributedText()
+    }
+  }
+
+  public var showInterestFreeText: Bool = true {
+    didSet {
+      updateAttributedText()
+    }
+  }
+
   public var textColor: UIColor = {
     if #available(iOS 13.0, *) {
       return .label
@@ -159,7 +171,12 @@ public final class PriceBreakdownView: UIView {
 
     let space = NSAttributedString(string: " ", attributes: textAttributes)
 
-    let priceBreakdown = PriceBreakdown(totalAmount: totalAmount, introText: introText)
+    let priceBreakdown = PriceBreakdown(
+      totalAmount: totalAmount,
+      introText: introText,
+      showInterestFreeText: showInterestFreeText,
+      showWithText: showWithText
+    )
     let breakdown = NSAttributedString(string: priceBreakdown.string, attributes: textAttributes)
 
     let badgePlacement = priceBreakdown.badgePlacement


### PR DESCRIPTION
## Summary of Changes

Added two options to the price breakdown component
- `showInterestFreeText`: A boolean that defaults to true and hides the word "interest-free" from the component if set to false
- `showWithText`: A boolean that defaults to true and hides the word "with" from the component if set to false

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] [Documentation](https://github.com/afterpay/sdk-ios/blob/f18e82da345b6532734ec4ae946d0adeca3e5c09/README.md#optional-text) is added.
