### PR TITLE
Fix: override nav bar style for modal

### DIFF
--- a/Sources/Afterpay/Info/InfoWebViewController.swift
+++ b/Sources/Afterpay/Info/InfoWebViewController.swift
@@ -32,6 +32,8 @@ final class InfoWebViewController: UIViewController, WKNavigationDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    self.extendedLayoutIncludesOpaqueBars = true
+
     if #available(iOS 13.0, *) {
       overrideUserInterfaceStyle = .light
       navigationItem.rightBarButtonItem = UIBarButtonItem(
@@ -47,10 +49,6 @@ final class InfoWebViewController: UIViewController, WKNavigationDelegate {
         action: #selector(dismissViewController)
       )
     }
-
-    // addresse a ui issue when the app globally sets the nav bar style. ie:
-    // UINavigationBar.appearance().isTranslucent = false
-    navigationController?.navigationBar.isTranslucent = true
   }
 
   override func viewDidAppear(_ animated: Bool) {

--- a/Sources/Afterpay/Info/InfoWebViewController.swift
+++ b/Sources/Afterpay/Info/InfoWebViewController.swift
@@ -47,6 +47,10 @@ final class InfoWebViewController: UIViewController, WKNavigationDelegate {
         action: #selector(dismissViewController)
       )
     }
+
+    // addresse a ui issue when the app globally sets the nav bar style. ie:
+    // UINavigationBar.appearance().isTranslucent = false
+    navigationController?.navigationBar.isTranslucent = true
   }
 
   override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## Summary of Changes

Change the way appearance of the modal looks for iOS 15+. The change will only be noticeable when nav bars are set to translucent globally.  This is primarily due to a change made in iOS 15, but to maintain consistency is added for 13+. The fix works by expanding the background of the modal up into the nav bar.

### Screen recordings

<details>
<summary>[1] iOS 15 without the change or global translucent nav bars (no code changes) ✅ </summary>
<br>This is what we want to get back to

https://user-images.githubusercontent.com/76413218/149840130-b1826539-a722-4bb5-957b-4855d1ce04db.mp4
</details>


<details>
<summary>[2] iOS 15 with global translucent nav bars ❌ </summary>
<br>This is what we want to fix. Notice the missing nav bar on the modal.<br>
This is achieved with the following: <code>navigationController?.navigationBar.isTranslucent = false</code>

https://user-images.githubusercontent.com/76413218/149840392-86bb874b-a69d-45fc-b0ed-cf7d0c7dd4bb.mp4
</details>


<details>
<summary>[3] iOS 15 with global translucent nav bars and the expanded background ✅ </summary>
<br>This video contains both global translucent nav bars (the code that broke the nav bars as evidenced in video 2) and the code from the change in this pr. The video shows the same result as video 1.


https://user-images.githubusercontent.com/76413218/149869912-ba8453dd-e96e-45c9-9fad-4a6f3fde51f6.mp4


</details>