### PR TITLE
Fix: bundle access

### DIFF
--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -9,8 +9,6 @@
 import Foundation
 import UIKit
 
-internal let bundle: Bundle = Bundle(identifier: "com.afterpay.Afterpay") ?? Bundle.main
-
 // MARK: - Checkout
 
 /// Present Afterpay Checkout modally over the specified view controller loading your

--- a/Sources/Afterpay/Model/Version.swift
+++ b/Sources/Afterpay/Model/Version.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 final class Version {
-  private static let bundle = Bundle(for: Version.self)
+  private static let bundle = Bundle.apResource
 
   static let shortVersion = bundle.infoDictionary!["CFBundleShortVersionString"] as! String
   static let sdkVersion = shortVersion + "-ios"


### PR DESCRIPTION
## Summary of Changes

- Remove the unused `bundle` property on the `Afterpay` class
- Change the way the bundle is referenced in the `Version` class for more accurate reading
