### PR TITLE
Fix: make the whole modal link tappable

### DIFF
--- a/Sources/Afterpay/Views/LinkTextView.swift
+++ b/Sources/Afterpay/Views/LinkTextView.swift
@@ -30,13 +30,13 @@ final class LinkTextView: UITextView, UITextViewDelegate {
   // Unfortunately implementing UITextViewDelegate textView(_:shouldInteractWith:in:interaction:)
   // for NSTextAttachments isn't enough to prevent drag and drop being initiated
   override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-    let characterIndex = layoutManager.characterIndex(
+    let index = layoutManager.characterIndex(
       for: point,
       in: textContainer,
       fractionOfDistanceBetweenInsertionPoints: nil
     )
 
-    let attribute = attributedText.attribute(.link, at: characterIndex, effectiveRange: nil)
+    let attribute = attributedText.attribute(.link, at: index, effectiveRange: nil)
 
     return attribute != nil
   }

--- a/Sources/Afterpay/Views/LinkTextView.swift
+++ b/Sources/Afterpay/Views/LinkTextView.swift
@@ -30,22 +30,13 @@ final class LinkTextView: UITextView, UITextViewDelegate {
   // Unfortunately implementing UITextViewDelegate textView(_:shouldInteractWith:in:interaction:)
   // for NSTextAttachments isn't enough to prevent drag and drop being initiated
   override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-    let isRightToLeft = traitCollection.layoutDirection == .rightToLeft
-    let direction: UITextLayoutDirection = isRightToLeft ? .right : .left
+    let characterIndex = layoutManager.characterIndex(
+      for: point,
+      in: textContainer,
+      fractionOfDistanceBetweenInsertionPoints: nil
+    )
 
-    guard
-      let position = closestPosition(to: point),
-      let range = tokenizer.rangeEnclosingPosition(
-        position,
-        with: .character,
-        inDirection: .layout(direction)
-      )
-    else {
-      return false
-    }
-
-    let index = offset(from: beginningOfDocument, to: range.start)
-    let attribute = attributedText.attribute(.link, at: index, effectiveRange: nil)
+    let attribute = attributedText.attribute(.link, at: characterIndex, effectiveRange: nil)
 
     return attribute != nil
   }


### PR DESCRIPTION
## Summary of Changes

Modify the method for getting a character's index in the `LinkTextView` class. The previous method was getting the index of the character based on the nearest cursor position to the tapped point. This would result in a different index depending on if the left side or right side of a character was tapped.

The new method uses the layout manager's `characterIndex` to get more reliable results.
