### PR TITLE
Fix: modify the method for setting the SDK version

### DIFF
--- a/Sources/Afterpay/Helpers/WKWebViewConfiguration+UserAgent.swift
+++ b/Sources/Afterpay/Helpers/WKWebViewConfiguration+UserAgent.swift
@@ -10,10 +10,6 @@ import WebKit
 
 extension WKWebViewConfiguration {
 
-  static let appNameForUserAgent: String? = {
-    Bundle(for: CheckoutV2ViewController.self)
-      .infoDictionary?["CFBundleShortVersionString"]
-      .map { "Afterpay-iOS-SDK/\($0)" }
-  }()
+  static let appNameForUserAgent = "Afterpay-iOS-SDK/\(Version.shortVersion)"
 
 }

--- a/Sources/Afterpay/Model/Version.swift
+++ b/Sources/Afterpay/Model/Version.swift
@@ -9,8 +9,6 @@
 import Foundation
 
 final class Version {
-  private static let bundle = Bundle.apResource
-
-  static let shortVersion = bundle.infoDictionary!["CFBundleShortVersionString"] as! String
-  static let sdkVersion = shortVersion + "-ios"
+  static let shortVersion = "4.5.2"
+  static let sdkVersion = "\(shortVersion)-ios"
 }


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- update the `Version` class with a hardcoded version number
- update the app name for the WebView's user agent to use the SDK version instead of the main app's version

## Items of Note

This change was made as the `CFBundleShortVersionString` key was not always available in the Afterpay bundles plist file.
