### PR TITLE
Remove grouping separator in sent amount for v3

### DIFF
--- a/AfterpayTests/CurrencyFormatterTests.swift
+++ b/AfterpayTests/CurrencyFormatterTests.swift
@@ -110,6 +110,10 @@ class CurrencyFormatterTests: XCTestCase {
     XCTAssertEqual(region.formatted(currency: 9.999), "10")
     XCTAssertEqual(region.formatted(currency: 9.995), "9.99")
     XCTAssertEqual(region.formatted(currency: 9.996), "10")
+    // This test was added to make sure that the grouping seperator
+    // was omitted from the formatted currency
+    // ie 1196.996 should not return 1,197 but 1197
+    XCTAssertEqual(region.formatted(currency: 1196.996), "1197")
   }
 
 }

--- a/Sources/Afterpay/AfterpayV3.swift
+++ b/Sources/Afterpay/AfterpayV3.swift
@@ -247,6 +247,7 @@ public struct CheckoutV3Configuration {
       // ISO 4217 specifies 2 decimal points
       formatter.maximumFractionDigits = 2
       formatter.roundingMode = .halfEven // Banker's rounding
+      formatter.groupingSeparator = ""
       return formatter
     }()
 


### PR DESCRIPTION
## Summary of Changes

This PR looks to fix the v3 checkout when totals exceed 999.99. The Afterpay API expects a string amount without a grouping separator. The formatter used was adding this grouping separator.

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Set formatter to use empty string as the grouping separator in v3
- Add tests for amount > 1000 ensuring no grouping separator

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] Tests are included.
