### PR TITLE
Prepare for release: v5.0.0

### DIFF
--- a/Configurations/Afterpay-Shared.xcconfig
+++ b/Configurations/Afterpay-Shared.xcconfig
@@ -169,4 +169,4 @@ TARGETED_DEVICE_FAMILY = 1,2
 // This setting defines the user-visible version of the project. The value corresponds to
 // the `CFBundleShortVersionString` key in your app's Info.plist.
 
-MARKETING_VERSION = 4.5.2
+MARKETING_VERSION = 5.0.0

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is the recommended integration method.
 
 ```
 dependencies: [
-    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "4.5.2"))
+    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "5.0.0"))
 ]
 ```
 
@@ -109,7 +109,7 @@ Add the Afterpay SDK as a [git submodule][git-submodule] by navigating to the ro
 ```
 git submodule add https://github.com/afterpay/sdk-ios.git Afterpay
 cd Afterpay
-git checkout 4.5.2
+git checkout 5.0.0
 ```
 
 #### Project / Workspace Integration

--- a/Sources/Afterpay/Model/Version.swift
+++ b/Sources/Afterpay/Model/Version.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 final class Version {
-  static let shortVersion = "4.5.2"
+  static let shortVersion = "5.0.0"
   static let sdkVersion = "\(shortVersion)-ios"
 }


### PR DESCRIPTION
## Summary of Changes

- Update version number from `4.5.2` to `5.0.0` in the following files: 
  - `README.md`
  - `Configurations/Afterpay-Shared.xcconfig`
  - `Sources/Afterpay/Model/Version.swift`