### PR TITLE
Feature: remove decimals for out of range messaging

### DIFF
--- a/AfterpayTests/PriceBreakdownTests.swift
+++ b/AfterpayTests/PriceBreakdownTests.swift
@@ -103,7 +103,7 @@ class PriceBreakdownTests: XCTestCase {
 
     for breakdown in outOfRangeBreakdowns {
       XCTAssertEqual(breakdown.badgePlacement, .start)
-      XCTAssertEqual(breakdown.string, "available for orders between $50.00 – $200.00")
+      XCTAssertEqual(breakdown.string, "available for orders between $50 – $200")
     }
   }
 
@@ -118,7 +118,7 @@ class PriceBreakdownTests: XCTestCase {
 
     for breakdown in outOfRangeBreakdowns {
       XCTAssertEqual(breakdown.badgePlacement, .start)
-      XCTAssertEqual(breakdown.string, "available for orders between $1.00 – $200.00")
+      XCTAssertEqual(breakdown.string, "available for orders between $1 – $200")
     }
   }
 

--- a/Example/Example/Components/ComponentsViewController.swift
+++ b/Example/Example/Components/ComponentsViewController.swift
@@ -166,7 +166,7 @@ private final class ContentStackViewController: UIViewController, PriceBreakdown
 
       let priceBreakdown1 = PriceBreakdownView()
       priceBreakdown1.introText = .payInTitle
-      priceBreakdown1.totalAmount = 100
+      priceBreakdown1.totalAmount = 103.50
       priceBreakdown1.delegate = self
       priceBreakdown1.moreInfoOptions = MoreInfoOptions(modalTheme: .white)
       stack.addArrangedSubview(priceBreakdown1)

--- a/Sources/Afterpay/Model/CurrencyFormatter.swift
+++ b/Sources/Afterpay/Model/CurrencyFormatter.swift
@@ -20,7 +20,7 @@ struct CurrencyFormatter {
     return formatter
   }()
 
-  func string(from decimal: Decimal) -> String? {
+  func string(from decimal: Decimal, maxDecimals: Int? = nil) -> String? {
     formatter.locale = clientLocale
 
     let currencyLocales = Locales.validArray.filter { $0.currencyCode == currencyCode }
@@ -60,6 +60,9 @@ struct CurrencyFormatter {
       default:
         formatter.positiveFormat = formatter.positiveFormat
       }
+    }
+    if maxDecimals != nil {
+      formatter.maximumFractionDigits = maxDecimals!
     }
 
     return formatter.string(from: decimal as NSDecimalNumber)

--- a/Sources/Afterpay/Model/PriceBreakdown.swift
+++ b/Sources/Afterpay/Model/PriceBreakdown.swift
@@ -25,19 +25,21 @@ struct PriceBreakdown {
     showWithText: Bool = true
   ) {
     let configuration = getConfiguration()
-    let formatter = configuration
-      .map { CurrencyFormatter(locale: $0.locale, currencyCode: $0.currencyCode, clientLocale: Locale.current) }
-    let format = { formatter?.string(from: $0) }
-
-    let formattedMinimum = configuration?.minimumAmount.flatMap(format) ?? formatter?.string(from: 1)
-    let formattedMaximum = (configuration?.maximumAmount).flatMap(format)
-    let numberOfInstalments = getNumberOfInstalments(currencyCode: configuration?.currencyCode)
-    let formattedPayment = format(totalAmount / numberOfInstalments)
 
     let greaterThanZero = totalAmount > .zero
     let greaterThanOrEqualToMinimum = totalAmount >= (configuration?.minimumAmount ?? .zero)
     let lessThanOrEqualToMaximum = totalAmount <= (configuration?.maximumAmount ?? .zero)
     let inRange = greaterThanZero && greaterThanOrEqualToMinimum && lessThanOrEqualToMaximum
+    let maxFractionDigits = !inRange ? 0 : nil
+
+    let formatter = configuration
+      .map { CurrencyFormatter(locale: $0.locale, currencyCode: $0.currencyCode, clientLocale: Locale.current) }
+    let format = { formatter?.string(from: $0, maxDecimals: maxFractionDigits) }
+
+    let formattedMinimum = configuration?.minimumAmount.flatMap(format) ?? formatter?.string(from: 1, maxDecimals: maxFractionDigits)
+    let formattedMaximum = (configuration?.maximumAmount).flatMap(format)
+    let numberOfInstalments = getNumberOfInstalments(currencyCode: configuration?.currencyCode)
+    let formattedPayment = format(totalAmount / numberOfInstalments)
 
     let isUkLocale = configuration?.locale == Locales.enGB
     let isGBP = configuration?.currencyCode == "GBP"


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Remove the decimal places for outside limit messaging to shorten and clean up the look of the price breakdown component

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [X] Tests are updated.

## Screenshots

| Previous | New |
|----------|-----|
|   <img width="502" alt="Screen Shot 2022-08-18 at 16 10 17" src="https://user-images.githubusercontent.com/76413218/185306762-0655e979-5322-4fd9-a34b-ea185dc17920.png">     |     <img width="449" alt="Screen Shot 2022-08-18 at 16 09 45" src="https://user-images.githubusercontent.com/76413218/185306846-587cad61-5e82-466a-b1c8-967f6c193d0f.png">     |





