### PR TITLE
EIT-2097: add support for reverse integrations

### DIFF
--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -196,6 +196,8 @@ final class PurchaseLogicController {
       errorMessageToShow = error.localizedDescription
     case .userInitiated:
       errorMessageToShow = nil
+    case .unretrievableUrl:
+      errorMessageToShow = nil
     case .invalidURL(let url):
       errorMessageToShow = "URL: \(url.absoluteString) is invalid for Afterpay Checkout"
     }

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -20,12 +20,15 @@ import UIKit
 ///   - checkoutURL: The checkout URL to load generated via the /checkouts endpoint on the
 ///   Afterpay backend.
 ///   - animated: Pass true to animate the presentation; otherwise, pass false.
+///   - shouldLoadRedirectUrls: a boolean for whether the redirect urls set when generating
+///   the checkout url should load. Default and recommended value is false
 ///   - completion: The block executed after the user has completed the checkout.
 ///   - result: The result of the user's completion (a success or cancellation).
 public func presentCheckoutModally(
   over viewController: UIViewController,
   loading checkoutURL: URL,
   animated: Bool = true,
+  shouldLoadRedirectUrls: Bool = false,
   completion: @escaping (_ result: CheckoutResult) -> Void
 ) {
   if !enabled {
@@ -34,6 +37,7 @@ public func presentCheckoutModally(
 
   var viewControllerToPresent: UIViewController = CheckoutWebViewController(
     checkoutUrl: checkoutURL,
+    shouldLoadRedirectUrls: shouldLoadRedirectUrls,
     completion: completion
   )
 

--- a/Sources/Afterpay/Model/CheckoutResult.swift
+++ b/Sources/Afterpay/Model/CheckoutResult.swift
@@ -14,6 +14,7 @@ import Foundation
 
   public enum CancellationReason {
     case userInitiated
+    case unretrievableUrl
     case networkError(Error)
     case invalidURL(URL)
   }

--- a/Sources/Afterpay/Wrappers/ObjcWrapper.swift
+++ b/Sources/Afterpay/Wrappers/ObjcWrapper.swift
@@ -57,6 +57,10 @@ public final class ObjcWrapper: NSObject {
       CancellationReasonUserInitiated(())
     }
 
+    static func unretrievableUrl() -> CancellationReasonUnretrievableUrl {
+      CancellationReasonUnretrievableUrl(())
+    }
+
     static func networkError(error: Error) -> CancellationReasonNetworkError {
       CancellationReasonNetworkError(error)
     }
@@ -68,6 +72,11 @@ public final class ObjcWrapper: NSObject {
 
   @objc(APCancellationReasonUserInitiated)
   public class CancellationReasonUserInitiated: CancellationReason {
+    init(_ void: ()) {}
+  }
+
+  @objc(APCancellationReasonUnretrievableUrl)
+  public class CancellationReasonUnretrievableUrl: CancellationReason {
     init(_ void: ()) {}
   }
 
@@ -107,6 +116,9 @@ public final class ObjcWrapper: NSObject {
 
         case .cancelled(.userInitiated):
           completion(.cancelled(reason: .userInitiated()))
+
+        case .cancelled(.unretrievableUrl):
+          completion(.cancelled(reason: .unretrievableUrl()))
 
         case .cancelled(.networkError(let error)):
           completion(.cancelled(reason: .networkError(error: error)))

--- a/Sources/Afterpay/Wrappers/SwiftUIWrapper.swift
+++ b/Sources/Afterpay/Wrappers/SwiftUIWrapper.swift
@@ -21,7 +21,8 @@ public extension View {
   ///   a checkout sheet is presented. If the URL changes a new sheet is presented. If nil is set
   ///   the sheet is dismissed.
   ///   - shouldLoadRedirectUrls: a boolean value that determines whether the redirect urls set
-  ///   when producing the checkout url should be redirected to. The default and recommended value is false
+  ///   when producing the checkout url should be allowed to start loading. The default and
+  ///   recommended value is false
   ///   - completion: Called with the result of a checkout after dismissal.
   func afterpayCheckout(
     url: Binding<URL?>,

--- a/Sources/Afterpay/Wrappers/SwiftUIWrapper.swift
+++ b/Sources/Afterpay/Wrappers/SwiftUIWrapper.swift
@@ -20,9 +20,12 @@ public extension View {
   ///   an Afterpay Checkout URL produced from the /checkouts endpoint. When a non nil URL is set,
   ///   a checkout sheet is presented. If the URL changes a new sheet is presented. If nil is set
   ///   the sheet is dismissed.
+  ///   - shouldLoadRedirectUrls: a boolean value that determines whether the redirect urls set
+  ///   when producing the checkout url should be redirected to. The default and recommended value is false
   ///   - completion: Called with the result of a checkout after dismissal.
   func afterpayCheckout(
     url: Binding<URL?>,
+    shouldLoadRedirectUrls: Bool = false,
     completion: @escaping (_ result: CheckoutResult) -> Void
   ) -> some View {
     let itemBinding: Binding<URLItem?> = Binding(
@@ -94,10 +97,15 @@ struct URLItem: Identifiable {
 struct SwiftUIWrapper: UIViewControllerRepresentable {
 
   let checkoutURL: URL
+  let shouldLoadRedirectUrls: Bool = false
   let completion: (_ result: CheckoutResult) -> Void
 
   func makeUIViewController(context: Context) -> CheckoutWebViewController {
-    CheckoutWebViewController(checkoutUrl: checkoutURL, completion: completion)
+    CheckoutWebViewController(
+      checkoutUrl: checkoutURL,
+      shouldLoadRedirectUrls: shouldLoadRedirectUrls,
+      completion: completion
+    )
   }
 
   func updateUIViewController(_ uiViewController: CheckoutWebViewController, context: Context) {

--- a/docs/src/getting-started/checkout-v1.md
+++ b/docs/src/getting-started/checkout-v1.md
@@ -33,6 +33,11 @@ import UIKit
 final class CheckoutViewController: UIViewController {
   // ...
   @objc func didTapPayWithAfterpay() {
+    /**
+     * `presentCheckoutModally` can take a `shouldLoadRedirectUrls` which is
+     * a boolean for whether the redirect urls set when generating
+     * the checkout url should load. Default and recommended value is false
+     */
     Afterpay.presentCheckoutModally(over: self, loading: self.checkoutUrl) { result in
       switch result {
       case .success(let token):


### PR DESCRIPTION
## Summary of Changes

- Allow redirect urls to be loaded for V1 if present checkout method is called (`Afterpay.presentCheckoutModally()`) with the new `shouldLoadRedirectUrls` parameter set to `true`

## Submission Checklist

- [x] Documentation is changed or added.