### PR TITLE
EIT-2198: Prepare for release: v5.2.0

### DIFF
--- a/Configurations/Afterpay-Shared.xcconfig
+++ b/Configurations/Afterpay-Shared.xcconfig
@@ -169,4 +169,4 @@ TARGETED_DEVICE_FAMILY = 1,2
 // This setting defines the user-visible version of the project. The value corresponds to
 // the `CFBundleShortVersionString` key in your app's Info.plist.
 
-MARKETING_VERSION = 5.1.0
+MARKETING_VERSION = 5.2.0

--- a/Sources/Afterpay/Model/Version.swift
+++ b/Sources/Afterpay/Model/Version.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 final class Version {
-  static let shortVersion = "5.1.0"
+  static let shortVersion = "5.2.0"
   static let sdkVersion = "\(shortVersion)-ios"
 }

--- a/docs/src/integration.md
+++ b/docs/src/integration.md
@@ -28,20 +28,20 @@ This is the recommended integration method.
 
 ``` swift
 dependencies: [
-    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "5.1.0"))
+    .package(url: "https://github.com/afterpay/sdk-ios.git", .upToNextMajor(from: "5.2.0"))
 ]
 ```
 
 ## Carthage
 
 ``` swift
-github "afterpay/sdk-ios" ~> 5.1
+github "afterpay/sdk-ios" ~> 5.2
 ```
 
 ## CocoaPods
 
 ``` swift
-pod 'Afterpay', '~> 5.1'
+pod 'Afterpay', '~> 5.2'
 ```
 ## Manual
 
@@ -60,7 +60,7 @@ Add the Afterpay SDK as a [git submodule][git-submodule]{:target="_blank"} by na
 ``` sh
 git submodule add https://github.com/afterpay/sdk-ios.git Afterpay
 cd Afterpay
-git checkout 5.1.0
+git checkout 5.2.0
 ```
 
 #### Project / Workspace Integration


### PR DESCRIPTION
## Summary of Changes

- Update version number from `5.1.0` to `5.2.0` in the following files: 
  - `docs/src/integration.md`
  - `Configurations/Afterpay-Shared.xcconfig`
  - `Sources/Afterpay/Model/Version.swift`