### PR TITLE
EIT-2361 - add ability to set consumer locale

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		45144E7227FD10E00061EBE8 /* AfterpayAssetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45144E7127FD10E00061EBE8 /* AfterpayAssetProvider.swift */; };
 		45144E7427FD11470061EBE8 /* AfterpayBundleFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45144E7327FD11470061EBE8 /* AfterpayBundleFinder.swift */; };
 		4559422027E04DDB00DF1956 /* ModalLinkStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4559421F27E04DDB00DF1956 /* ModalLinkStyle.swift */; };
+		4573E4B42A4D4DCB00F5CEAA /* LocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4573E4B32A4D4DCB00F5CEAA /* LocaleTests.swift */; };
 		458E7D37296E1F9D001B696F /* CashAppSigningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458E7D36296E1F9D001B696F /* CashAppSigningResult.swift */; };
 		45BFEB9827ED27EF00A4AE48 /* Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BFEB9727ED27EF00A4AE48 /* Brand.swift */; };
 		45D406D127FE4B67009AA4EE /* LogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D406D027FE4B67009AA4EE /* LogoView.swift */; };
@@ -109,6 +110,7 @@
 		45144E7127FD10E00061EBE8 /* AfterpayAssetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterpayAssetProvider.swift; sourceTree = "<group>"; };
 		45144E7327FD11470061EBE8 /* AfterpayBundleFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterpayBundleFinder.swift; sourceTree = "<group>"; };
 		4559421F27E04DDB00DF1956 /* ModalLinkStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalLinkStyle.swift; sourceTree = "<group>"; };
+		4573E4B32A4D4DCB00F5CEAA /* LocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleTests.swift; sourceTree = "<group>"; };
 		458E7D36296E1F9D001B696F /* CashAppSigningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashAppSigningResult.swift; sourceTree = "<group>"; };
 		45BFEB9727ED27EF00A4AE48 /* Brand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Brand.swift; sourceTree = "<group>"; };
 		45D406D027FE4B67009AA4EE /* LogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoView.swift; sourceTree = "<group>"; };
@@ -278,6 +280,7 @@
 				550D481A26255D8600C0B0C6 /* WidgetEventTests.swift */,
 				550D48142625539900C0B0C6 /* WidgetStatusTests.swift */,
 				557511BA264259C30040CC51 /* CombineWrapperTests.swift */,
+				4573E4B32A4D4DCB00F5CEAA /* LocaleTests.swift */,
 			);
 			path = AfterpayTests;
 			sourceTree = "<group>";
@@ -580,6 +583,7 @@
 				550D48152625539900C0B0C6 /* WidgetStatusTests.swift in Sources */,
 				557511BB264259C30040CC51 /* CombineWrapperTests.swift in Sources */,
 				66C3F7FB25397A810086DD0A /* CurrencyFormatterTests.swift in Sources */,
+				4573E4B42A4D4DCB00F5CEAA /* LocaleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AfterpayTests/LocaleTests.swift
+++ b/AfterpayTests/LocaleTests.swift
@@ -1,0 +1,90 @@
+//
+//  LocaleTests.swift
+//  AfterpayTests
+//
+//  Created by Scott Antonac on 29/6/2023.
+//  Copyright © 2023 Afterpay. All rights reserved.
+//
+
+import Afterpay
+import XCTest
+
+private struct LocaleCombination {
+  let merchantLocale: Locale
+  let consumerLocale: Locale
+  let valid: Bool
+}
+
+class LocaleTests: XCTestCase {
+  let one = "1.00"
+  let oneThousand = "1000.00"
+  let usdCode = "USD"
+
+  let enUsLocale = Locale(identifier: "en_US")
+  let enAuLocale = Locale(identifier: "en_AU")
+  let enCaLocale = Locale(identifier: "en_CA")
+  let frCaLocale = Locale(identifier: "fr_CA")
+  let frFrLocale = Locale(identifier: "fr_FR")
+  let esEsLocale = Locale(identifier: "es_ES")
+
+  let esUsLocale = Locale(identifier: "es_US")
+  let jpJPLocale = Locale(identifier: "jp_JP")
+
+  func testLocaleCombinationValid() {
+    let localeCombinations: [LocaleCombination] = [
+      LocaleCombination(merchantLocale: enUsLocale, consumerLocale: enUsLocale, valid: true),
+      LocaleCombination(merchantLocale: enUsLocale, consumerLocale: enAuLocale, valid: true),
+      LocaleCombination(merchantLocale: enUsLocale, consumerLocale: esUsLocale, valid: false),
+      LocaleCombination(merchantLocale: enUsLocale, consumerLocale: frCaLocale, valid: false),
+      LocaleCombination(merchantLocale: enUsLocale, consumerLocale: jpJPLocale, valid: false),
+
+      LocaleCombination(merchantLocale: enAuLocale, consumerLocale: enAuLocale, valid: true),
+      LocaleCombination(merchantLocale: enAuLocale, consumerLocale: enUsLocale, valid: true),
+      LocaleCombination(merchantLocale: enAuLocale, consumerLocale: esUsLocale, valid: false),
+      LocaleCombination(merchantLocale: enAuLocale, consumerLocale: frCaLocale, valid: false),
+      LocaleCombination(merchantLocale: enAuLocale, consumerLocale: jpJPLocale, valid: false),
+
+      LocaleCombination(merchantLocale: enCaLocale, consumerLocale: enCaLocale, valid: true),
+      LocaleCombination(merchantLocale: enCaLocale, consumerLocale: enUsLocale, valid: true),
+      LocaleCombination(merchantLocale: enCaLocale, consumerLocale: esUsLocale, valid: false),
+      LocaleCombination(merchantLocale: enCaLocale, consumerLocale: frCaLocale, valid: true),
+      LocaleCombination(merchantLocale: enCaLocale, consumerLocale: frFrLocale, valid: true),
+      LocaleCombination(merchantLocale: enCaLocale, consumerLocale: jpJPLocale, valid: false),
+
+      LocaleCombination(merchantLocale: frCaLocale, consumerLocale: enCaLocale, valid: true),
+      LocaleCombination(merchantLocale: frCaLocale, consumerLocale: enUsLocale, valid: true),
+      LocaleCombination(merchantLocale: frCaLocale, consumerLocale: esUsLocale, valid: false),
+      LocaleCombination(merchantLocale: frCaLocale, consumerLocale: frCaLocale, valid: true),
+      LocaleCombination(merchantLocale: frCaLocale, consumerLocale: frFrLocale, valid: true),
+      LocaleCombination(merchantLocale: frCaLocale, consumerLocale: jpJPLocale, valid: false),
+
+      LocaleCombination(merchantLocale: frFrLocale, consumerLocale: frFrLocale, valid: true),
+      LocaleCombination(merchantLocale: frFrLocale, consumerLocale: enAuLocale, valid: true),
+      LocaleCombination(merchantLocale: frFrLocale, consumerLocale: esUsLocale, valid: false),
+      LocaleCombination(merchantLocale: frFrLocale, consumerLocale: esEsLocale, valid: false),
+      LocaleCombination(merchantLocale: frFrLocale, consumerLocale: frCaLocale, valid: true),
+      LocaleCombination(merchantLocale: frFrLocale, consumerLocale: enUsLocale, valid: true),
+      LocaleCombination(merchantLocale: frFrLocale, consumerLocale: jpJPLocale, valid: false),
+    ]
+
+    for combination in localeCombinations {
+      Afterpay.setConfiguration(
+        // swiftlint:disable:next force_try
+        try! Configuration(
+          minimumAmount: one,
+          maximumAmount: oneThousand,
+          currencyCode: usdCode,
+          locale: combination.merchantLocale,
+          environment: .sandbox,
+          consumerLocale: combination.consumerLocale
+        )
+      )
+
+      XCTAssertEqual(
+        Afterpay.enabled,
+        combination.valid,
+        "Merchant: \(combination.merchantLocale), Consumer: \(combination.consumerLocale)"
+      )
+    }
+  }
+}

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -397,7 +397,10 @@ func getLocale() -> Locale {
 }
 
 internal var language: Locale? {
-  getRegionLanguage(merchantLocale: getLocale(), clientLocale: Locale.current)
+  getRegionLanguage(
+    merchantLocale: getLocale(),
+    clientLocale: getConfiguration()?.consumerLocale ?? Locale.current
+  )
 }
 
 internal var string: Strings {

--- a/Sources/Afterpay/Model/Configuration.swift
+++ b/Sources/Afterpay/Model/Configuration.swift
@@ -42,6 +42,7 @@ public struct Configuration {
   public var currencyCode: String
   public var locale: Locale
   public var environment: Environment
+  public var consumerLocale: Locale?
 
   /// Creates a new configuration by taking in a minimum and maximum amount as well as a currency
   /// code and locale.
@@ -84,7 +85,8 @@ public struct Configuration {
     maximumAmount: String,
     currencyCode: String,
     locale: Locale,
-    environment: Environment
+    environment: Environment,
+    consumerLocale: Locale? = nil
   ) throws {
     let minimumSupplied = minimumAmount != nil
     let minimumDecimal = minimumAmount.flatMap { Decimal(string: $0) }
@@ -116,6 +118,7 @@ public struct Configuration {
     self.currencyCode = currencyCode
     self.locale = locale
     self.environment = environment
+    self.consumerLocale = consumerLocale
   }
 
 }


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Allow the consumer locale to be manually set via a `Configuration` object. This will fallback to the device locale if not set

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] Tests are included.
