### PR TITLE
feat: support consumerLocale in obj-c [EIT-3944]

### DIFF
--- a/Sources/Afterpay/Wrappers/ObjcWrapper.swift
+++ b/Sources/Afterpay/Wrappers/ObjcWrapper.swift
@@ -146,6 +146,7 @@ public final class ObjcWrapper: NSObject {
     currencyCode: String,
     locale: Locale,
     environment: String,
+    consumerLocale: Locale,
     error: UnsafeMutablePointer<NSError>
   ) {
     let environment = Environment(rawValue: environment) ?? .production
@@ -155,7 +156,8 @@ public final class ObjcWrapper: NSObject {
         maximumAmount: maximumAmount,
         currencyCode: currencyCode,
         locale: locale,
-        environment: environment)
+        environment: environment,
+        consumerLocale: consumerLocale)
     }
 
     switch result {


### PR DESCRIPTION
## Summary of Changes

Add support for setting consumer locale in configuration to the obj-c wrapper

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Add `consumerLocale` param to function
- Call pass `consumerLocale` into `setConfiguration` call
