### PR TITLE
fix(docs): change px to rem for compatibility

### DIFF
--- a/docs/src/_sass/color_schemes/afterpay.scss
+++ b/docs/src/_sass/color_schemes/afterpay.scss
@@ -3,5 +3,5 @@
 $link-color: #3d75ca;
 $feedback-color: rgb(223, 234, 246);
 $sidebar-color: $white;
-$nav-width: 300px;
-$nav-width-md: 300px;
+$nav-width: 18.75rem;
+$nav-width-md: 18.75rem;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
Just the docs theme had updated in the past to use rem instead of px. This was causing compilation errors with the customisation.

- update px to rem for compat with just-the-docs theme
