### PR TITLE
fix(obj-c): make cashAppClientId public

### DIFF
--- a/Sources/Afterpay/Wrappers/ObjcWrapper.swift
+++ b/Sources/Afterpay/Wrappers/ObjcWrapper.swift
@@ -173,7 +173,7 @@ public final class ObjcWrapper: NSObject {
   // Cash App
   // swiftlint:disable type_name
 
-  @objc static var cashAppClientId: String? {
+  @objc public static var cashAppClientId: String? {
     Afterpay.cashAppClientId
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

Ensure that `cashAppClientId` is exposed correctly to Obj-c by marking it public