### PR TITLE
Button with Cash App Pay

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		557511BF2644CAA50040CC51 /* WKWebView+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */; };
 		557511C12644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */; };
 		55A2D307261BB36C00D8E23A /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A2D306261BB36C00D8E23A /* Money.swift */; };
+		5FB958DA2C0A526800137468 /* CheckoutV3CashAppPayResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958D92C0A526800137468 /* CheckoutV3CashAppPayResult.swift */; };
+		5FB958DC2C0A528300137468 /* ConfirmationV3+CashAppPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
 		66169312257A06B200DF6CF4 /* CheckoutV2Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66169311257A06B200DF6CF4 /* CheckoutV2Message.swift */; };
@@ -140,6 +142,8 @@
 		557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Cache.swift"; sourceTree = "<group>"; };
 		557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebViewConfiguration+UserAgent.swift"; sourceTree = "<group>"; };
 		55A2D306261BB36C00D8E23A /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
+		5FB958D92C0A526800137468 /* CheckoutV3CashAppPayResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutV3CashAppPayResult.swift; sourceTree = "<group>"; };
+		5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfirmationV3+CashAppPay.swift"; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
 		66169311257A06B200DF6CF4 /* CheckoutV2Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutV2Message.swift; sourceTree = "<group>"; };
@@ -233,6 +237,8 @@
 				4509D358294017C500952DAD /* CashAppSigningResponse.swift */,
 				4509D356293FFB5200952DAD /* CashAppPayCheckout.swift */,
 				458E7D36296E1F9D001B696F /* CashAppSigningResult.swift */,
+				5FB958D92C0A526800137468 /* CheckoutV3CashAppPayResult.swift */,
+				5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */,
 			);
 			path = CashApp;
 			sourceTree = "<group>";
@@ -633,8 +639,10 @@
 				6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */,
 				42087EE727A746F700BE5442 /* MoreInfoOptions.swift in Sources */,
 				66B5458C256B65B7002B3DD5 /* CheckoutHost.swift in Sources */,
+				5FB958DA2C0A526800137468 /* CheckoutV3CashAppPayResult.swift in Sources */,
 				66169312257A06B200DF6CF4 /* CheckoutV2Message.swift in Sources */,
 				45144E7427FD11470061EBE8 /* AfterpayBundleFinder.swift in Sources */,
+				5FB958DC2C0A528300137468 /* ConfirmationV3+CashAppPay.swift in Sources */,
 				666818202591CB9800A2003E /* Alerts.swift in Sources */,
 				45144E7027FCEFA30061EBE8 /* LockupView.swift in Sources */,
 				6689536C24C96CB5005090B4 /* Configuration.swift in Sources */,

--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		55A2D307261BB36C00D8E23A /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A2D306261BB36C00D8E23A /* Money.swift */; };
 		5FB958DA2C0A526800137468 /* CheckoutV3CashAppPayResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958D92C0A526800137468 /* CheckoutV3CashAppPayResult.swift */; };
 		5FB958DC2C0A528300137468 /* ConfirmationV3+CashAppPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */; };
+		5FB958DE2C0E00DC00137468 /* AfterpayV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */; };
+		5FB958E32C0E126200137468 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958E22C0E126200137468 /* URLSessionMock.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
 		66169312257A06B200DF6CF4 /* CheckoutV2Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66169311257A06B200DF6CF4 /* CheckoutV2Message.swift */; };
@@ -144,6 +146,8 @@
 		55A2D306261BB36C00D8E23A /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
 		5FB958D92C0A526800137468 /* CheckoutV3CashAppPayResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutV3CashAppPayResult.swift; sourceTree = "<group>"; };
 		5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfirmationV3+CashAppPay.swift"; sourceTree = "<group>"; };
+		5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterpayV3Tests.swift; sourceTree = "<group>"; };
+		5FB958E22C0E126200137468 /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
 		66169311257A06B200DF6CF4 /* CheckoutV2Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutV2Message.swift; sourceTree = "<group>"; };
@@ -252,6 +256,14 @@
 			path = Widget;
 			sourceTree = "<group>";
 		};
+		5FB958E12C0E124E00137468 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				5FB958E22C0E126200137468 /* URLSessionMock.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		661B233024DA87EA0010EBCD /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -299,6 +311,7 @@
 		665FC5782488766C00A5A93E /* AfterpayTests */ = {
 			isa = PBXGroup;
 			children = (
+				5FB958E12C0E124E00137468 /* Mocks */,
 				556DEBF92653531000BFC277 /* mock-widget-bootstrap.js */,
 				6635B95E24CAA9F000EBB3A6 /* ConfigurationTests.swift */,
 				66C3F7FA25397A810086DD0A /* CurrencyFormatterTests.swift */,
@@ -309,6 +322,7 @@
 				550D48142625539900C0B0C6 /* WidgetStatusTests.swift */,
 				557511BA264259C30040CC51 /* CombineWrapperTests.swift */,
 				4573E4B32A4D4DCB00F5CEAA /* LocaleTests.swift */,
+				5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */,
 			);
 			path = AfterpayTests;
 			sourceTree = "<group>";
@@ -616,8 +630,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5FB958E32C0E126200137468 /* URLSessionMock.swift in Sources */,
 				551BEDF125F98FA800FDF9EE /* FeaturesTests.swift in Sources */,
 				6635B95F24CAA9F000EBB3A6 /* ConfigurationTests.swift in Sources */,
+				5FB958DE2C0E00DC00137468 /* AfterpayV3Tests.swift in Sources */,
 				66DAAC8D24E109D200127460 /* PriceBreakdownTests.swift in Sources */,
 				550D481B26255D8600C0B0C6 /* WidgetEventTests.swift in Sources */,
 				550D48152625539900C0B0C6 /* WidgetStatusTests.swift in Sources */,

--- a/AfterpayTests/AfterpayV3Tests.swift
+++ b/AfterpayTests/AfterpayV3Tests.swift
@@ -1,0 +1,180 @@
+//
+//  AfterpayV3Tests.swift
+//  AfterpayTests
+//
+//  Created by Mark Mroz on 2024-06-03.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+import XCTest
+@testable import Afterpay
+
+final class AfterpayV3Tests: XCTestCase {
+
+  private var v3Configuration: CheckoutV3Configuration!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    v3Configuration = CheckoutV3Configuration(
+      shopDirectoryMerchantId: "merchant_id",
+      region: .US,
+      environment: .production
+    )
+
+    let v2Configuration = try Configuration(
+      minimumAmount: nil,
+      maximumAmount: "150",
+      currencyCode: "USD",
+      locale: Locale(identifier: "en_US"),
+      environment: .production
+    )
+    Afterpay.setConfiguration(v2Configuration)
+  }
+
+  override func tearDown() {
+    v3Configuration = nil
+    Afterpay.setConfiguration(nil)
+    super.tearDown()
+  }
+
+  func testCheckoutV3WithCashAppPay() throws {
+    let checkoutV3Expectation = self.expectation(description: "Checkout V3")
+    let checkoutHandler: URLRequestHandler = { (request, response) in
+      URLSessionMock(dataTaskHandler: { url in
+        XCTAssertEqual(url.absoluteString, "https://api-plus.us.afterpay.com/v3/button")
+        return (Fixtures.checkoutV3WithCashAppPayResponse, nil, nil)
+      }).dataTask(with: request.url!) { data, urlResponse, error in
+        checkoutV3Expectation.fulfill()
+        response(data, urlResponse, error)
+      }
+    }
+
+    let signTokenExpectation = self.expectation(description: "Sign Token")
+    let signHandler = URLSessionMock(requestDataTaskHandler: { request in
+      XCTAssertEqual(request.url?.absoluteString, "https://api-plus.us.afterpay.com/v2/payments/sign-payment")
+      signTokenExpectation.fulfill()
+      return (Fixtures.signPaymentResponse, HTTPURLResponse(), nil)
+    })
+
+    let checkoutExpectation = self.expectation(description: "Completed Checkout")
+    Afterpay.checkoutV3WithCashAppPay(
+      consumer: Consumer(email: "jack@xyz.com"),
+      orderTotal: OrderTotal(total: 10, shipping: 0, tax: 0),
+      items: [Product(name: "Coffee", quantity: 1, price: 10)],
+      configuration: v3Configuration,
+      urlSession: signHandler,
+      requestHandler: checkoutHandler
+    ) { result in
+      switch result {
+      case .success(let data):
+        XCTAssertEqual(data.singleUseCardToken, "AQI")
+        XCTAssertEqual(data.token, "002.x")
+        XCTAssertEqual(data.cashAppSigningData.amount, 5000)
+        XCTAssertEqual(data.cashAppSigningData.brandId, "BRAND_ID")
+        XCTAssertEqual(data.cashAppSigningData.merchantId, "MMI_6nvgu9voweagwt5dn0kdteaio")
+        XCTAssertEqual(
+          data.cashAppSigningData.redirectUri.absoluteString,
+          "https://static-us.afterpay.com/javascript/button/index.html"
+        )
+      case .cancelled, .failure:
+        XCTFail("Expected success")
+      }
+      checkoutExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 0.5)
+  }
+
+  func testCheckoutV3ConfirmForCashAppPay() {
+
+    let confirmRequestExpectation = self.expectation(description: "Confirmed")
+    let checkoutHandler: URLRequestHandler = { (request, response) in
+      URLSessionMock(dataTaskHandler: { url in
+        XCTAssertEqual(url.absoluteString, "https://api-plus.us.afterpay.com/v3/button/confirm")
+        return (Fixtures.confirmResponse, nil, nil)
+      }).dataTask(with: request.url!) { data, urlResponse, error in
+        confirmRequestExpectation.fulfill()
+        response(data, urlResponse, error)
+      }
+    }
+
+    let confirmExpectation = self.expectation(description: "Confirmed")
+    Afterpay.checkoutV3ConfirmForCashAppPay(
+      token: "002.x",
+      singleUseCardToken: "AQI",
+      cashAppPayCustomerID: "CUST_ID",
+      cashAppPayGrantID: "GRR_ID",
+      jwt: "JWT",
+      configuration: v3Configuration,
+      requestHandler: checkoutHandler
+    ) { result in
+      switch result {
+      case .success(let data):
+        XCTAssertEqual(data.paymentDetails.virtualCard?.cardType, "VISA")
+        XCTAssertEqual(data.paymentDetails.virtualCard?.cardNumber, "4111111111111111")
+        XCTAssertEqual(data.paymentDetails.virtualCard?.cvc, "737")
+        XCTAssertEqual(data.paymentDetails.virtualCard?.expiryMonth, 3)
+        XCTAssertEqual(data.paymentDetails.virtualCard?.expiryYear, 30)
+        XCTAssertNotNil(data.cardValidUntil)
+      case .failure:
+        XCTFail("Expected success")
+      }
+
+      confirmExpectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.5)
+  }
+}
+
+// MARK: - Private
+
+private extension AfterpayV3Tests {
+  struct Product: CheckoutV3Item {
+    let name: String
+    let quantity: UInt
+    let price: Decimal
+    let sku: String? = nil
+    let pageUrl: URL? = nil
+    let imageUrl: URL? = nil
+    let categories: [[String]]? = nil
+    let estimatedShipmentDate: String? = nil
+  }
+}
+
+// MARK: - Fixtures
+
+extension AfterpayV3Tests {
+  // swiftlint:disable line_length indentation_width
+  enum Fixtures {
+    static let checkoutV3WithCashAppPayResponse = """
+    {
+        "token":  "002.x",
+        "confirmMustBeCalledBefore": "2024-06-04T02:29:53.803Z",
+        "redirectCheckoutUrl": "https://portal.sandbox.afterpay.com/us/checkout/?token=002.x",
+        "singleUseCardToken": "AQI"
+    }
+    """.data(using: .utf8)
+
+    static let signPaymentResponse = """
+    {
+        "jwtToken":  "eyJraWQiOiJrZXkxIiwiYWxnIjoiRVMyNTYiLCJ0dGwiOiIxNzE3NDM3Nzc1In0.eyJleHRlcm5hbE1lcmNoYW50SWQiOiJNTUlfNm52Z3U5dm93ZWFnd3Q1ZG4wa2R0ZWFpbyIsInRva2VuIjoiMDAyLmlscXFqZjJ1ZG11MnJwM3hjdTdjYjZtenVwNnRlZndiM2Q1eWs2Y3pyZnZqd3Nmb2NuIiwiYW1vdW50Ijp7ImFtb3VudCI6IjUwLjAwIiwiY3VycmVuY3kiOiJVU0QiLCJzeW1ib2wiOiIkIn0sInJlZGlyZWN0VXJsIjoiaHR0cHM6Ly9zdGF0aWMtdXMuYWZ0ZXJwYXkuY29tL2phdmFzY3JpcHQvYnV0dG9uL2luZGV4Lmh0bWwifQ.KRVxIHwrH_QPDTX2WF3Ei5wI7InE_v7xvPDDXFF2YBka2hUROkSX6ubdrFufIkE6yaFHyrlAGoQiS17VB80IDA",
+        "redirectUrl":  "https://static-us.afterpay.com",
+        "externalBrandId":  "BRAND_ID"
+    }
+    """.data(using: .utf8)
+
+    static let confirmResponse = """
+    {
+        "paymentDetails": {
+            "virtualCard":  {
+                "cardType":  "VISA",
+                "cardNumber":  "4111111111111111",
+                "cvc":  "737",
+                "expiry":  "30-03"
+            }
+        },
+        "cardValidUntil": "2024-06-03T18:31:32.096071575Z"
+    }
+    """.data(using: .utf8)
+  }
+}

--- a/AfterpayTests/Mocks/URLSessionMock.swift
+++ b/AfterpayTests/Mocks/URLSessionMock.swift
@@ -26,14 +26,14 @@ final class URLSessionDataTaskMock: URLSessionDataTask {
 
 final class URLSessionMock: URLSession {
   typealias RequestDataTaskHandler = (URLRequest) -> (Data?, URLResponse?, Error?)
-  typealias DataTaskHandler = (URL) -> (Data?, URLResponse?, Error?)
+  typealias URLDataTaskHandler = (URL) -> (Data?, URLResponse?, Error?)
   typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
 
-  private let dataTaskHandler: DataTaskHandler
+  private let dataTaskHandler: URLDataTaskHandler
   private let requestDataTaskHandler: RequestDataTaskHandler
 
   init(
-    dataTaskHandler: @escaping DataTaskHandler = { _ in (nil, nil, nil) },
+    dataTaskHandler: @escaping URLDataTaskHandler = { _ in (nil, nil, nil) },
     requestDataTaskHandler: @escaping RequestDataTaskHandler = { _ in (nil, nil, nil) }
   ) {
     self.dataTaskHandler = dataTaskHandler

--- a/AfterpayTests/Mocks/URLSessionMock.swift
+++ b/AfterpayTests/Mocks/URLSessionMock.swift
@@ -1,0 +1,62 @@
+//
+//  URLSessionMock.swift
+//  AfterpayTests
+//
+//  Created by Mark Mroz on 2024-06-03.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - URLSessionDataTaskMock
+
+final class URLSessionDataTaskMock: URLSessionDataTask {
+  private let resumeHandler: () -> Void
+
+  init(resumeHandler: @escaping () -> Void) {
+    self.resumeHandler = resumeHandler
+  }
+
+  override func resume() {
+    resumeHandler()
+  }
+}
+
+// MARK: - URLSessionMock
+
+final class URLSessionMock: URLSession {
+  typealias RequestDataTaskHandler = (URLRequest) -> (Data?, URLResponse?, Error?)
+  typealias DataTaskHandler = (URL) -> (Data?, URLResponse?, Error?)
+  typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
+
+  private let dataTaskHandler: DataTaskHandler
+  private let requestDataTaskHandler: RequestDataTaskHandler
+
+  init(
+    dataTaskHandler: @escaping DataTaskHandler = { _ in (nil, nil, nil) },
+    requestDataTaskHandler: @escaping RequestDataTaskHandler = { _ in (nil, nil, nil) }
+  ) {
+    self.dataTaskHandler = dataTaskHandler
+    self.requestDataTaskHandler = requestDataTaskHandler
+  }
+
+  override func dataTask(
+    with url: URL,
+    completionHandler: @escaping CompletionHandler
+  ) -> URLSessionDataTask {
+    let (data, response, error) = dataTaskHandler(url)
+    return URLSessionDataTaskMock {
+      completionHandler(data, response, error)
+    }
+  }
+
+  override func dataTask(
+    with request: URLRequest,
+    completionHandler: @escaping CompletionHandler
+  ) -> URLSessionDataTask {
+    let (data, response, error) = requestDataTaskHandler(request)
+    return URLSessionDataTaskMock {
+      completionHandler(data, response, error)
+    }
+  }
+}

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		55432838263B7EC2005512E4 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55432837263B7EC2005512E4 /* ExampleUITests.swift */; };
 		55719BA926363ED800634B27 /* SwiftUIWidgetExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55719BA826363ED800634B27 /* SwiftUIWidgetExample.swift */; };
 		55FA7270260025DC0006EFCB /* WidgetHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FA726F260025DC0006EFCB /* WidgetHandler.swift */; };
+		5FB958E62C0E3D7B00137468 /* CheckoutPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958E52C0E3D7B00137468 /* CheckoutPickerView.swift */; };
 		660072B724A1B55E00E9A2BC /* TextSettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660072B624A1B55E00E9A2BC /* TextSettingCell.swift */; };
 		6620B5D224934FB3004162BC /* AppFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6620B5D124934FB3004162BC /* AppFlowController.swift */; };
 		663A228E249B030D0027C296 /* WidgetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663A228D249B030D0027C296 /* WidgetViewController.swift */; };
@@ -100,6 +101,7 @@
 		55432839263B7EC2005512E4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55719BA826363ED800634B27 /* SwiftUIWidgetExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIWidgetExample.swift; sourceTree = "<group>"; };
 		55FA726F260025DC0006EFCB /* WidgetHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetHandler.swift; sourceTree = "<group>"; };
+		5FB958E52C0E3D7B00137468 /* CheckoutPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutPickerView.swift; sourceTree = "<group>"; };
 		660072B624A1B55E00E9A2BC /* TextSettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSettingCell.swift; sourceTree = "<group>"; };
 		6620B5D124934FB3004162BC /* AppFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowController.swift; sourceTree = "<group>"; };
 		663A228D249B030D0027C296 /* WidgetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetViewController.swift; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				83F7DEE2269D2BAA00F9FB75 /* SingleUseCardResultViewController.swift */,
 				66BD11B324ADB7EB00039DA6 /* TitleSubtitleCell.swift */,
 				55FA726F260025DC0006EFCB /* WidgetHandler.swift */,
+				5FB958E52C0E3D7B00137468 /* CheckoutPickerView.swift */,
 			);
 			path = Purchase;
 			sourceTree = "<group>";
@@ -503,6 +506,7 @@
 			files = (
 				1535ACB725DBA8AD00727818 /* CheckoutHandler.swift in Sources */,
 				152224B124AAF7AE006E7D78 /* Objc.m in Sources */,
+				5FB958E62C0E3D7B00137468 /* CheckoutPickerView.swift in Sources */,
 				6650F41C24BC03DC00B16A57 /* Colors.swift in Sources */,
 				6620B5D224934FB3004162BC /* AppFlowController.swift in Sources */,
 				664722A724A5D9B00079B1FB /* AlertFactory.swift in Sources */,

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -20,9 +20,17 @@ final class CartViewController: UIViewController, UITableViewDataSource {
   private let titleSubtitleCellIdentifier = String(describing: TitleSubtitleCell.self)
   private let eventHandler: (Event) -> Void
 
+  private var event: Event = .didTapSingleUseCardButton {
+    didSet {
+      updateViewState()
+    }
+  }
+
   private lazy var cashButton = CashAppPayButton(size: .large) { [weak self] in
     self?.didTapCashAppPay()
   }
+
+  private let checkoutTypeTextField = UITextField()
 
   enum Event {
     case didTapPay
@@ -30,6 +38,7 @@ final class CartViewController: UIViewController, UITableViewDataSource {
     case cartDidLoad(CashAppPayButton)
     case optionsChanged(CheckoutOptionsCell.Event)
     case didTapSingleUseCardButton
+    case didTapSingleUseCardButtonWithCashAppPay
   }
 
   init(cart: CartDisplay, eventHandler: @escaping (Event) -> Void) {
@@ -70,15 +79,22 @@ final class CartViewController: UIViewController, UITableViewDataSource {
       payButton.addTarget(self, action: #selector(didTapPay), for: .touchUpInside)
 
       view.addSubview(payButton)
+      view.addSubview(checkoutTypeTextField)
 
       cashButton.accessibilityIdentifier = "payWithCashApp"
       cashButton.translatesAutoresizingMaskIntoConstraints = false
 
+      checkoutTypeTextField.translatesAutoresizingMaskIntoConstraints = false
+
       view.addSubview(cashButton)
 
       NSLayoutConstraint.activate([
+        checkoutTypeTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+        checkoutTypeTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+        checkoutTypeTextField.bottomAnchor.constraint(equalTo: payButton.topAnchor),
         payButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
         payButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+        payButton.bottomAnchor.constraint(equalTo: cashButton.topAnchor),
         cashButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
         cashButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
         cashButton.topAnchor.constraint(equalTo: payButton.bottomAnchor, constant: 8),
@@ -94,22 +110,49 @@ final class CartViewController: UIViewController, UITableViewDataSource {
       tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
       tableViewBottomAnchor,
     ])
+
+    let editCheckoutButton = UIBarButtonItem(
+      title: "Edit",
+      style: .plain,
+      target: self,
+      action: #selector(presentPickerController)
+    )
+    navigationItem.setRightBarButton(editCheckoutButton, animated: false)
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
-
     eventHandler(.cartDidLoad(self.cashButton))
+
+    updateViewState()
+  }
+
+  // MARK: - Private
+
+  func updateViewState() {
+    switch event {
+    case .didTapPay, .didTapCashAppPay, .cartDidLoad, .optionsChanged:
+      break
+    case .didTapSingleUseCardButton:
+      checkoutTypeTextField.text = "Button Checkout V3"
+    case .didTapSingleUseCardButtonWithCashAppPay:
+      checkoutTypeTextField.text = "Button Checkout V3 with Cash App Pay"
+    }
   }
 
   // MARK: Actions
 
   @objc private func didTapPay() {
-    eventHandler(.didTapSingleUseCardButton)
+    eventHandler(event)
   }
 
   @objc private func didTapCashAppPay() {
     eventHandler(.didTapCashAppPay)
+  }
+
+  @objc private func presentPickerController() {
+    let controller = CheckoutPickerViewController(delegate: self)
+    present(UINavigationController(rootViewController: controller), animated: true)
   }
 
   // MARK: UITableViewDataSource
@@ -188,4 +231,22 @@ final class CartViewController: UIViewController, UITableViewDataSource {
     fatalError("init(coder:) has not been implemented")
   }
 
+}
+
+// MARK: - CheckoutPickerControllerDelegate
+
+extension CartViewController: CheckoutPickerControllerDelegate {
+  func didSelectCancel(_ controller: CheckoutPickerViewController) {
+    controller.dismiss(animated: true)
+  }
+  
+  func didSelectV3Checkout(_ controller: CheckoutPickerViewController) {
+    event = .didTapSingleUseCardButton
+    controller.dismiss(animated: true)
+  }
+
+  func didSelectV3CheckoutWithCashAppPay(_ controller: CheckoutPickerViewController) {
+    event = .didTapSingleUseCardButtonWithCashAppPay
+    controller.dismiss(animated: true)
+  }
 }

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -11,7 +11,6 @@ import Foundation
 import PayKitUI
 
 final class CartViewController: UIViewController, UITableViewDataSource {
-
   private var tableView: UITableView!
   private let cart: CartDisplay
   private let genericCellIdentifier = String(describing: UITableViewCell.self)
@@ -94,7 +93,6 @@ final class CartViewController: UIViewController, UITableViewDataSource {
         checkoutTypeTextField.bottomAnchor.constraint(equalTo: payButton.topAnchor),
         payButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
         payButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-        payButton.bottomAnchor.constraint(equalTo: cashButton.topAnchor),
         cashButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
         cashButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
         cashButton.topAnchor.constraint(equalTo: payButton.bottomAnchor, constant: 8),
@@ -151,7 +149,20 @@ final class CartViewController: UIViewController, UITableViewDataSource {
   }
 
   @objc private func presentPickerController() {
-    let controller = CheckoutPickerViewController(delegate: self)
+    let selectedOption: CheckoutPickerOption?
+    switch event {
+    case .didTapSingleUseCardButton:
+      selectedOption = .button
+    case .didTapSingleUseCardButtonWithCashAppPay:
+      selectedOption = .buttonWithCashAppPay
+    default:
+      selectedOption = nil
+    }
+
+    guard let selectedOption else { return }
+
+    let controller = CheckoutPickerViewController(selectedOption: selectedOption, delegate: self)
+    controller.title = "Configuration"
     present(UINavigationController(rootViewController: controller), animated: true)
   }
 
@@ -239,7 +250,7 @@ extension CartViewController: CheckoutPickerControllerDelegate {
   func didSelectCancel(_ controller: CheckoutPickerViewController) {
     controller.dismiss(animated: true)
   }
-  
+
   func didSelectV3Checkout(_ controller: CheckoutPickerViewController) {
     event = .didTapSingleUseCardButton
     controller.dismiss(animated: true)

--- a/Example/Example/Purchase/CheckoutPickerView.swift
+++ b/Example/Example/Purchase/CheckoutPickerView.swift
@@ -1,0 +1,103 @@
+//
+//  CheckoutPickerView.swift
+//  Example
+//
+//  Created by Mark Mroz on 2024-06-03.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+import SwiftUI
+
+protocol CheckoutPickerControllerDelegate: AnyObject {
+  func didSelectCancel(_ controller: CheckoutPickerViewController)
+  func didSelectV3Checkout(_ controller: CheckoutPickerViewController)
+  func didSelectV3CheckoutWithCashAppPay(_ controller: CheckoutPickerViewController)
+}
+
+final class CheckoutPickerViewController: UIViewController {
+
+  private lazy var viewModel = makePickerViewModel()
+  private lazy var pickerView = PickerView(viewModel: viewModel)
+
+  private weak var delegate: CheckoutPickerControllerDelegate?
+
+  init(delegate: CheckoutPickerControllerDelegate?) {
+    self.delegate = delegate
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func loadView() {
+    let container = UIView(frame: .zero)
+    let view = UIHostingController(rootView: pickerView).view!
+    container.addSubview(view)
+    container.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate([
+      container.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      container.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      container.topAnchor.constraint(equalTo: view.topAnchor),
+      container.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+
+    self.view = view
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    let cancelButton = UIBarButtonItem(
+      title: "Close",
+      style: .plain,
+      target: self,
+      action: #selector(onCancelTapped)
+    )
+    navigationItem.setRightBarButton(cancelButton, animated: false)
+  }
+
+  // MARK: - Actions
+
+  @objc private func onCancelTapped() {
+    delegate?.didSelectCancel(self)
+  }
+
+  // MARK: - Private
+
+  private func makePickerViewModel() -> PickerViewModel {
+    PickerViewModel(
+      onButtonTapped: { [weak self] in
+        guard let self else { return }
+        delegate?.didSelectV3Checkout(self)
+      },
+      onButtonWithCashAppPayTapped: { [weak self] in
+        guard let self else { return }
+        delegate?.didSelectV3CheckoutWithCashAppPay(self)
+      }
+    )
+  }
+}
+
+extension CheckoutPickerViewController {
+  struct PickerViewModel {
+    let onButtonTapped: () -> Void
+    let onButtonWithCashAppPayTapped: () -> Void
+  }
+
+  struct PickerView: View {
+
+    private let viewModel: PickerViewModel
+
+    init(viewModel: PickerViewModel) {
+      self.viewModel = viewModel
+    }
+
+    var body: some View {
+      VStack(alignment: .leading) {
+        Button("Button Checkout", action: viewModel.onButtonTapped).padding()
+        Button("Button Checkout With Cash App Pay", action: viewModel.onButtonWithCashAppPayTapped).padding()
+      }
+    }
+  }
+}

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -108,6 +108,8 @@ final class PurchaseFlowController: UIViewController {
           logicController.toggleExpressCheckout()
         case .didTapSingleUseCardButton:
           logicController.payWithAfterpayV3()
+        case .didTapSingleUseCardButtonWithCashAppPay:
+          logicController.payWithAfterpayV3WithCashAppPay()
         }
       }
 
@@ -156,6 +158,50 @@ final class PurchaseFlowController: UIViewController {
           logicController.cancelled(with: reason)
         }
       }
+    case let .afterpayCheckoutV3WithCashAppPay(consumer, cart):
+      Afterpay.checkoutV3WithCashAppPay(
+        consumer: consumer,
+        orderTotal: OrderTotal(total: cart.total, shipping: 0, tax: 0)) { result in
+          switch result {
+          case .success(let data):
+            logicController.doCap(cashAppPayload: data)
+          case .cancelled:
+            let alert = AlertFactory.alert(successMessage: "Canceled")
+            navigationController.present(alert, animated: true, completion: nil)
+          case .failure(let error):
+            let alert = AlertFactory.alert(for: error)
+            navigationController.present(alert, animated: true, completion: nil)
+          }
+        }
+    case let .confirmAfterpayCheckoutV3WithCashAppPay(
+      token: token,
+      singleUseCardToke: cardToken,
+      customerID: customerID,
+      grantID: grantID,
+      jwt: jwt
+    ):
+      Afterpay.checkoutV3ConfirmForCashAppPay(
+        token: token,
+        singleUseCardToken: cardToken,
+        cashAppPayCustomerID: customerID,
+        cashAppPayGrantID: grantID,
+        jwt: jwt) { response in
+          print(response)
+          switch response {
+          case .success(let success):
+            let message = [
+              "Card": success.paymentDetails.virtualCard?.cardNumber,
+              "Expires": success.cardValidUntil.map { RelativeDateTimeFormatter().string(for: $0) ?? "" },
+            ].compactMapValues { $0 }
+              .map { (key: String, value: String) in key + ": " + value }
+              .joined(separator: "\n")
+            let alert = AlertFactory.alert(successMessage: message)
+            navigationController.present(alert, animated: true, completion: nil)
+          case .failure(let error):
+            let alert = AlertFactory.alert(for: error)
+            navigationController.present(alert, animated: true, completion: nil)
+          }
+        }
 
     case .provideCheckoutTokenResult(let tokenResult):
       checkoutHandler.provideTokenResult(tokenResult: tokenResult)

--- a/Example/Example/Shared/AlertFactory.swift
+++ b/Example/Example/Shared/AlertFactory.swift
@@ -35,4 +35,11 @@ import UIKit
     return alert
   }
 
+  static func alert(successMessage: String) -> UIAlertController {
+    let alert = UIAlertController(title: "Success", message: nil, preferredStyle: .alert)
+    alert.addAction(UIAlertAction(title: "Okay", style: .default, handler: nil))
+    alert.message = successMessage
+    return alert
+  }
+
 }

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -240,6 +240,7 @@ public func setCheckoutV2Handler(_ handler: CheckoutV2Handler?) {
 
 public func signCashAppOrderToken(
   _ token: Token,
+  urlSession: URLSession = .shared,
   completion: @escaping (_ result: CashAppSigningResult) -> Void
 ) {
   guard let configuration = getConfiguration() else {
@@ -253,6 +254,7 @@ public func signCashAppOrderToken(
   }
 
   let cashAppCheckout = CashAppPayCheckout(
+    urlSession: urlSession,
     configuration: configuration,
     completion: completion
   )

--- a/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
+++ b/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
@@ -186,3 +186,80 @@ class CashAppPayCheckout {
     }.resume()
   }
 }
+
+// MARK: - CheckoutV3
+
+internal extension CashAppPayCheckout {
+  // swiftlint:disable:next function_parameter_count
+  static func checkoutV3Confirm(
+    token: String,
+    singleUseCardToken: String,
+    cashAppPayCustomerID: String,
+    cashAppPayGrantID: String,
+    jwt: String,
+    configuration: CheckoutV3Configuration,
+    requestHandler: @escaping URLRequestHandler,
+    completion: @escaping (Result<ConfirmationV3.CashAppPayResponse, Error>) -> Void
+  ) {
+    let parameters = ConfirmationV3.CashAppPayRequest(
+      token: token,
+      singleUseCardToken: singleUseCardToken,
+      cashAppPspInfo: ConfirmationV3.CashAppPayRequest.CashAppPspInfo(
+        externalCustomerId: cashAppPayCustomerID,
+        externalGrantId: cashAppPayGrantID,
+        jwt: jwt
+      )
+    )
+
+    var request = ApiV3.request(from: configuration.v3CheckoutConfirmationUrl)
+    do {
+      request.httpBody = try JSONEncoder().encode(parameters)
+    } catch {
+      completion(.failure(error))
+    }
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+    ApiV3.request(
+      requestHandler, request,
+      type: ConfirmationV3.CashAppPayResponse.self,
+      completion: completion
+    ).resume()
+  }
+
+  // swiftlint:disable:next function_parameter_count
+  static func checkoutV3(
+    consumer: CheckoutV3Consumer,
+    orderTotal: OrderTotal,
+    items: [CheckoutV3Item] = [],
+    configuration: CheckoutV3Configuration,
+    requestHandler: @escaping URLRequestHandler,
+    completion: @escaping (Result<CheckoutV3.Response, Error>) -> Void
+  ) {
+    let parameters =  CheckoutV3.Request(
+      consumer: consumer,
+      orderTotal: orderTotal,
+      items: items,
+      isCashAppPay: true,
+      configuration: configuration
+    )
+
+    var request = ApiV3.request(from: configuration.v3CheckoutUrl)
+    do {
+      request.httpBody = try JSONEncoder().encode(parameters)
+    } catch {
+      completion(.failure(error))
+      return
+    }
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+    ApiV3.request(
+      requestHandler, request,
+      type: CheckoutV3.Response.self,
+      completion: completion
+    ).resume()
+  }
+}

--- a/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
+++ b/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
@@ -9,13 +9,16 @@
 import Foundation
 
 class CashAppPayCheckout {
+  private let urlSession: URLSession
   private let configuration: Configuration
   private let completion: (_ result: CashAppSigningResult) -> Void
 
   public init(
+    urlSession: URLSession,
     configuration: Configuration,
     completion: @escaping (_ result: CashAppSigningResult) -> Void
   ) {
+    self.urlSession = urlSession
     self.configuration = configuration
     self.completion = completion
   }
@@ -55,7 +58,7 @@ class CashAppPayCheckout {
     request: URLRequest,
     signingCompletion: @escaping (_ jwt: CashAppSigningResult) -> Void
   ) {
-    URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+    urlSession.dataTask(with: request) { [weak self] data, response, error in
       if error != nil {
         signingCompletion(CashAppSigningResult.failed(reason: .error(error: error!)))
         return
@@ -228,7 +231,6 @@ internal extension CashAppPayCheckout {
     ).resume()
   }
 
-  // swiftlint:disable:next function_parameter_count
   static func checkoutV3(
     consumer: CheckoutV3Consumer,
     orderTotal: OrderTotal,

--- a/Sources/Afterpay/CashApp/CheckoutV3CashAppPayResult.swift
+++ b/Sources/Afterpay/CashApp/CheckoutV3CashAppPayResult.swift
@@ -1,0 +1,21 @@
+//
+//  CheckoutV3CashAppPayResult.swift
+//  Afterpay
+//
+//  Created by Mark Mroz on 2024-05-31.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+public struct CheckoutV3CashAppPayPayload {
+  public let token: Token
+  public let singleUseCardToken: String
+  public let cashAppSigningData: CashAppSigningData
+}
+
+@frozen public enum CheckoutV3CashAppPayResult {
+  case success(data: CheckoutV3CashAppPayPayload)
+  case cancelled(reason: CashAppSigningResult.CashAppSigningCancellationReason)
+  case failure(error: Error)
+}

--- a/Sources/Afterpay/CashApp/ConfirmationV3+CashAppPay.swift
+++ b/Sources/Afterpay/CashApp/ConfirmationV3+CashAppPay.swift
@@ -1,0 +1,27 @@
+//
+//  ConfirmationV3+CashAppPay.swift .swift
+//  Afterpay
+//
+//  Created by Mark Mroz on 2024-05-31.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+extension ConfirmationV3 {
+  struct CashAppPayRequest: Encodable {
+    struct CashAppPspInfo: Encodable {
+      let externalCustomerId: String
+      let externalGrantId: String
+      let jwt: String
+    }
+    let token: String
+    let singleUseCardToken: String
+    let cashAppPspInfo: CashAppPspInfo
+  }
+
+  public struct CashAppPayResponse: Decodable {
+    public let paymentDetails: ConfirmationV3.Response.PaymentDetails
+    public let cardValidUntil: Date?
+  }
+}

--- a/Sources/Afterpay/CashApp/ConfirmationV3+CashAppPay.swift
+++ b/Sources/Afterpay/CashApp/ConfirmationV3+CashAppPay.swift
@@ -10,11 +10,6 @@ import Foundation
 
 extension ConfirmationV3 {
   struct CashAppPayRequest: Encodable {
-    struct CashAppPspInfo: Encodable {
-      let externalCustomerId: String
-      let externalGrantId: String
-      let jwt: String
-    }
     let token: String
     let singleUseCardToken: String
     let cashAppPspInfo: CashAppPspInfo
@@ -23,5 +18,13 @@ extension ConfirmationV3 {
   public struct CashAppPayResponse: Decodable {
     public let paymentDetails: ConfirmationV3.Response.PaymentDetails
     public let cardValidUntil: Date?
+  }
+}
+
+extension ConfirmationV3.CashAppPayRequest {
+  struct CashAppPspInfo: Encodable {
+    let externalCustomerId: String
+    let externalGrantId: String
+    let jwt: String
   }
 }

--- a/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV2ViewController.swift
@@ -17,8 +17,7 @@ final class CheckoutV2ViewController:
   UIAdaptivePresentationControllerDelegate,
   WKNavigationDelegate,
   WKScriptMessageHandler,
-  WKUIDelegate
-{ // swiftlint:disable:this opening_brace
+  WKUIDelegate {
 
   private let configuration: Configuration
   private let options: CheckoutV2Options

--- a/Sources/Afterpay/Checkout/CheckoutV3.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV3.swift
@@ -25,10 +25,13 @@ enum CheckoutV3 {
     let shipping: Contact?
     let billing: Contact?
 
+    let isCashAppPay: Bool
+
     init(
       consumer: CheckoutV3Consumer,
       orderTotal: OrderTotal,
       items: [CheckoutV3Item] = [],
+      isCashAppPay: Bool = false,
       configuration: CheckoutV3Configuration
     ) {
       self.shopDirectoryId = configuration.shopDirectoryId
@@ -60,6 +63,8 @@ enum CheckoutV3 {
 
       self.shipping = Contact(consumer.shippingInformation)
       self.billing = Contact(consumer.billingInformation)
+
+      self.isCashAppPay = isCashAppPay
     }
 
     // MARK: - Inner types

--- a/Sources/Afterpay/Checkout/CheckoutV3ViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV3ViewController.swift
@@ -13,8 +13,7 @@ import WebKit
 final class CheckoutV3ViewController:
   UIViewController,
   UIAdaptivePresentationControllerDelegate,
-  WKNavigationDelegate
-{ // swiftlint:disable:this opening_brace
+  WKNavigationDelegate {
 
   private let checkout: CheckoutV3.Request
   private let buyNow: Bool

--- a/Sources/Afterpay/Checkout/CheckoutWebViewController.swift
+++ b/Sources/Afterpay/Checkout/CheckoutWebViewController.swift
@@ -13,8 +13,7 @@ import WebKit
 final class CheckoutWebViewController:
   UIViewController,
   UIAdaptivePresentationControllerDelegate,
-  WKNavigationDelegate
-{ // swiftlint:disable:this opening_brace
+  WKNavigationDelegate {
 
   private let checkoutUrl: URL
   private let shouldLoadRedirectUrls: Bool

--- a/Sources/Afterpay/Checkout/ConfirmationV3.swift
+++ b/Sources/Afterpay/Checkout/ConfirmationV3.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 // swiftlint:disable nesting
-enum ConfirmationV3 {
+public enum ConfirmationV3 {
 
   struct Request: Encodable {
     let token: String
@@ -17,14 +17,14 @@ enum ConfirmationV3 {
     let ppaConfirmToken: String
   }
 
-  struct Response: Decodable {
+  public struct Response: Decodable {
     let paymentDetails: PaymentDetails
     let cardValidUntil: Date?
     let authToken: String
 
-    struct PaymentDetails: Decodable {
-      let virtualCard: Card?
-      let virtualCardToken: TokenizedCard?
+    public struct PaymentDetails: Decodable {
+      public let virtualCard: Card?
+      public let virtualCardToken: TokenizedCard?
     }
   }
 


### PR DESCRIPTION
We can now use:
- `checkoutV3WithCashAppPay()`
- then take the redirectUrl/ externalBrandId and use Cash App Pay SDK to get a grant and customer
- finally call `checkoutV3ConfirmForCashAppPay()` 


https://github.com/afterpay/sdk-ios/assets/8743061/a1800215-b728-4a8a-b5b4-97283585f74a