### PR TITLE
V3Configs for Cash App Pay checkout

### DIFF
--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		5FB958DC2C0A528300137468 /* ConfirmationV3+CashAppPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */; };
 		5FB958DE2C0E00DC00137468 /* AfterpayV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */; };
 		5FB958E32C0E126200137468 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958E22C0E126200137468 /* URLSessionMock.swift */; };
+		5FBAABA02C1B3109003558AF /* CashAppPayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FBAAB9F2C1B3109003558AF /* CashAppPayTests.swift */; };
 		6602EF0F25358A8000A0468C /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6602EF0E25358A8000A0468C /* ColorScheme.swift */; };
 		6605666324E5199500DA588E /* Locales.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6605666224E5199500DA588E /* Locales.swift */; };
 		66169312257A06B200DF6CF4 /* CheckoutV2Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66169311257A06B200DF6CF4 /* CheckoutV2Message.swift */; };
@@ -148,6 +149,7 @@
 		5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfirmationV3+CashAppPay.swift"; sourceTree = "<group>"; };
 		5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterpayV3Tests.swift; sourceTree = "<group>"; };
 		5FB958E22C0E126200137468 /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
+		5FBAAB9F2C1B3109003558AF /* CashAppPayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashAppPayTests.swift; sourceTree = "<group>"; };
 		6602EF0E25358A8000A0468C /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorScheme.swift; sourceTree = "<group>"; };
 		6605666224E5199500DA588E /* Locales.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locales.swift; sourceTree = "<group>"; };
 		66169311257A06B200DF6CF4 /* CheckoutV2Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutV2Message.swift; sourceTree = "<group>"; };
@@ -323,6 +325,7 @@
 				557511BA264259C30040CC51 /* CombineWrapperTests.swift */,
 				4573E4B32A4D4DCB00F5CEAA /* LocaleTests.swift */,
 				5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */,
+				5FBAAB9F2C1B3109003558AF /* CashAppPayTests.swift */,
 			);
 			path = AfterpayTests;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 				550D48152625539900C0B0C6 /* WidgetStatusTests.swift in Sources */,
 				557511BB264259C30040CC51 /* CombineWrapperTests.swift in Sources */,
 				66C3F7FB25397A810086DD0A /* CurrencyFormatterTests.swift in Sources */,
+				5FBAABA02C1B3109003558AF /* CashAppPayTests.swift in Sources */,
 				4573E4B42A4D4DCB00F5CEAA /* LocaleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Afterpay.xcodeproj/project.pbxproj
+++ b/Afterpay.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		557511BF2644CAA50040CC51 /* WKWebView+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */; };
 		557511C12644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */; };
 		55A2D307261BB36C00D8E23A /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A2D306261BB36C00D8E23A /* Money.swift */; };
+		5F4336942C1FC3F700ECD0DE /* CheckoutV3RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4336932C1FC3F700ECD0DE /* CheckoutV3RequestTests.swift */; };
+		5F4336982C1FC48C00ECD0DE /* KeyedEncodingContainerProtocolExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4336972C1FC48C00ECD0DE /* KeyedEncodingContainerProtocolExtensionTests.swift */; };
+		5F4336992C1FC8E600ECD0DE /* KeyedEncodingContainerProtocol+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4336952C1FC46300ECD0DE /* KeyedEncodingContainerProtocol+Extensions.swift */; };
 		5FB958DA2C0A526800137468 /* CheckoutV3CashAppPayResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958D92C0A526800137468 /* CheckoutV3CashAppPayResult.swift */; };
 		5FB958DC2C0A528300137468 /* ConfirmationV3+CashAppPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */; };
 		5FB958DE2C0E00DC00137468 /* AfterpayV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */; };
@@ -145,6 +148,9 @@
 		557511BE2644CAA50040CC51 /* WKWebView+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Cache.swift"; sourceTree = "<group>"; };
 		557511C02644D0890040CC51 /* WKWebViewConfiguration+UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebViewConfiguration+UserAgent.swift"; sourceTree = "<group>"; };
 		55A2D306261BB36C00D8E23A /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
+		5F4336932C1FC3F700ECD0DE /* CheckoutV3RequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutV3RequestTests.swift; sourceTree = "<group>"; };
+		5F4336952C1FC46300ECD0DE /* KeyedEncodingContainerProtocol+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedEncodingContainerProtocol+Extensions.swift"; sourceTree = "<group>"; };
+		5F4336972C1FC48C00ECD0DE /* KeyedEncodingContainerProtocolExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedEncodingContainerProtocolExtensionTests.swift; sourceTree = "<group>"; };
 		5FB958D92C0A526800137468 /* CheckoutV3CashAppPayResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutV3CashAppPayResult.swift; sourceTree = "<group>"; };
 		5FB958DB2C0A528300137468 /* ConfirmationV3+CashAppPay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfirmationV3+CashAppPay.swift"; sourceTree = "<group>"; };
 		5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterpayV3Tests.swift; sourceTree = "<group>"; };
@@ -233,6 +239,7 @@
 				45144E7127FD10E00061EBE8 /* AfterpayAssetProvider.swift */,
 				45144E7327FD11470061EBE8 /* AfterpayBundleFinder.swift */,
 				4509D35A2940192400952DAD /* JWT.swift */,
+				5F4336952C1FC46300ECD0DE /* KeyedEncodingContainerProtocol+Extensions.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -326,6 +333,8 @@
 				4573E4B32A4D4DCB00F5CEAA /* LocaleTests.swift */,
 				5FB958DD2C0E00DC00137468 /* AfterpayV3Tests.swift */,
 				5FBAAB9F2C1B3109003558AF /* CashAppPayTests.swift */,
+				5F4336932C1FC3F700ECD0DE /* CheckoutV3RequestTests.swift */,
+				5F4336972C1FC48C00ECD0DE /* KeyedEncodingContainerProtocolExtensionTests.swift */,
 			);
 			path = AfterpayTests;
 			sourceTree = "<group>";
@@ -643,7 +652,9 @@
 				557511BB264259C30040CC51 /* CombineWrapperTests.swift in Sources */,
 				66C3F7FB25397A810086DD0A /* CurrencyFormatterTests.swift in Sources */,
 				5FBAABA02C1B3109003558AF /* CashAppPayTests.swift in Sources */,
+				5F4336942C1FC3F700ECD0DE /* CheckoutV3RequestTests.swift in Sources */,
 				4573E4B42A4D4DCB00F5CEAA /* LocaleTests.swift in Sources */,
+				5F4336982C1FC48C00ECD0DE /* KeyedEncodingContainerProtocolExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -699,6 +710,7 @@
 				55432830263A61C4005512E4 /* CombineWrapper.swift in Sources */,
 				42DA4F9826E0740500204E75 /* IntroText.swift in Sources */,
 				4509D351293473F500952DAD /* CompactBadgeView.swift in Sources */,
+				5F4336992C1FC8E600ECD0DE /* KeyedEncodingContainerProtocol+Extensions.swift in Sources */,
 				45D406D127FE4B67009AA4EE /* LogoView.swift in Sources */,
 				157E88D125CBCA49007E54C4 /* Result+Fold.swift in Sources */,
 				55A2D307261BB36C00D8E23A /* Money.swift in Sources */,

--- a/AfterpayTests/AfterpayV3Tests.swift
+++ b/AfterpayTests/AfterpayV3Tests.swift
@@ -117,6 +117,10 @@ final class AfterpayV3Tests: XCTestCase {
 
     waitForExpectations(timeout: 0.5)
   }
+
+  func testCashAppClientIdForV3() {
+    XCTAssertEqual(Afterpay.checkoutV3CashAppClientId, "CA-CI_AFTERPAY")
+  }
 }
 
 // MARK: - Private

--- a/AfterpayTests/AfterpayV3Tests.swift
+++ b/AfterpayTests/AfterpayV3Tests.swift
@@ -21,19 +21,12 @@ final class AfterpayV3Tests: XCTestCase {
       environment: .production
     )
 
-    let v2Configuration = try Configuration(
-      minimumAmount: nil,
-      maximumAmount: "150",
-      currencyCode: "USD",
-      locale: Locale(identifier: "en_US"),
-      environment: .production
-    )
-    Afterpay.setConfiguration(v2Configuration)
+    Afterpay.setV3Configuration(v3Configuration)
   }
 
   override func tearDown() {
     v3Configuration = nil
-    Afterpay.setConfiguration(nil)
+    Afterpay.setV3Configuration(nil)
     super.tearDown()
   }
 

--- a/AfterpayTests/CashAppPayTests.swift
+++ b/AfterpayTests/CashAppPayTests.swift
@@ -1,0 +1,42 @@
+//
+//  CashAppPayTests.swift
+//  AfterpayTests
+//
+//  Created by Mark Mroz on 2024-06-13.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+import XCTest
+@testable import Afterpay
+
+final class CashAppPayTests: XCTestCase {
+  func testSignCashAppOrderToken() {
+    let signingURL = "https://api-plus.us.afterpay.com/v2/payments/sign-payment"
+    let signTokenExpectation = self.expectation(description: "Sign Token")
+    let handle = URLSessionMock(requestDataTaskHandler: { request in
+      XCTAssertEqual(request.url?.absoluteString, signingURL)
+
+      return (Fixtures.signPaymentResponse, HTTPURLResponse(), nil)
+    })
+
+    CashAppPayCheckout.signCashAppOrderToken("Token", cashAppSigningURL: signingURL, urlSession: handle) { _ in
+      signTokenExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 0.5)
+  }
+}
+
+// MARK: - Fixtures
+
+extension CashAppPayTests {
+  // swiftlint:disable line_length indentation_width
+  enum Fixtures {
+    static let signPaymentResponse = """
+    {
+        "jwtToken":  "eyJraWQiOiJrZXkxIiwiYWxnIjoiRVMyNTYiLCJ0dGwiOiIxNzE3NDM3Nzc1In0.eyJleHRlcm5hbE1lcmNoYW50SWQiOiJNTUlfNm52Z3U5dm93ZWFnd3Q1ZG4wa2R0ZWFpbyIsInRva2VuIjoiMDAyLmlscXFqZjJ1ZG11MnJwM3hjdTdjYjZtenVwNnRlZndiM2Q1eWs2Y3pyZnZqd3Nmb2NuIiwiYW1vdW50Ijp7ImFtb3VudCI6IjUwLjAwIiwiY3VycmVuY3kiOiJVU0QiLCJzeW1ib2wiOiIkIn0sInJlZGlyZWN0VXJsIjoiaHR0cHM6Ly9zdGF0aWMtdXMuYWZ0ZXJwYXkuY29tL2phdmFzY3JpcHQvYnV0dG9uL2luZGV4Lmh0bWwifQ.KRVxIHwrH_QPDTX2WF3Ei5wI7InE_v7xvPDDXFF2YBka2hUROkSX6ubdrFufIkE6yaFHyrlAGoQiS17VB80IDA",
+        "redirectUrl":  "https://static-us.afterpay.com",
+        "externalBrandId":  "BRAND_ID"
+    }
+    """.data(using: .utf8)
+  }
+}

--- a/AfterpayTests/CheckoutV3RequestTests.swift
+++ b/AfterpayTests/CheckoutV3RequestTests.swift
@@ -1,0 +1,78 @@
+//
+//  CheckoutV3RequestTests.swift
+//  AfterpayTests
+//
+//  Created by Mark Mroz on 2024-06-16.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+@testable import Afterpay
+import XCTest
+
+final class CheckoutV3RequestTests: XCTestCase {
+  func testEncodingWithCashAppIncludesEncodedKey() throws {
+    let customer = Customer(
+      email: "jack@email.com",
+      givenNames: nil,
+      surname: nil,
+      phoneNumber: nil,
+      shippingInformation: nil,
+      billingInformation: nil
+    )
+    let request = CheckoutV3.Request(
+      consumer: customer,
+      orderTotal: OrderTotal(total: 1, shipping: 1, tax: 0),
+      items: [],
+      isCashAppPay: true,
+      configuration: CheckoutV3Configuration(shopDirectoryMerchantId: "", region: .US, environment: .production)
+    )
+    let encoded = try JSONEncoder().encode(request)
+    let stringData = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+    XCTAssert(stringData.localizedCaseInsensitiveContains("isCashApp"))
+  }
+
+  func testEncodingWithoutCashAppDoesNotIncludeEncodedKey() throws {
+    let customer = Customer(
+      email: "jack@email.com",
+      givenNames: nil,
+      surname: nil,
+      phoneNumber: nil,
+      shippingInformation: nil,
+      billingInformation: nil
+    )
+    
+    let request = CheckoutV3.Request(
+      consumer: customer,
+      orderTotal: OrderTotal(total: 1, shipping: 1, tax: 0),
+      items: [],
+      isCashAppPay: false,
+      configuration: CheckoutV3Configuration(shopDirectoryMerchantId: "", region: .US, environment: .production)
+    )
+    let encoded = try JSONEncoder().encode(request)
+    let stringData = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+    XCTAssertFalse(stringData.localizedCaseInsensitiveContains("isCashApp"))
+  }
+}
+
+private extension CheckoutV3RequestTests {
+  struct Customer: CheckoutV3Consumer {
+    let email: String
+    let givenNames: String?
+    let surname: String?
+    let phoneNumber: String?
+    let shippingInformation: CheckoutV3Contact?
+    let billingInformation: CheckoutV3Contact?
+  }
+
+  struct Contact: CheckoutV3Contact {
+    let name: String
+    let line1: String
+    let line2: String?
+    let area1: String?
+    let area2: String?
+    let region: String?
+    let postcode: String?
+    let countryCode: String
+    let phoneNumber: String?
+  }
+}

--- a/AfterpayTests/KeyedEncodingContainerProtocolExtensionTests.swift
+++ b/AfterpayTests/KeyedEncodingContainerProtocolExtensionTests.swift
@@ -1,0 +1,46 @@
+//
+//  KeyedEncodingContainerProtocolExtensionTests.swift
+//  AfterpayTests
+//
+//  Created by Mark Mroz on 2024-06-16.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+@testable import Afterpay
+import XCTest
+
+final class KeyedEncodingContainerProtocolTests: XCTestCase {
+  func testEncodeIfTrue() throws {
+    let encoder = JSONEncoder()
+
+    let params = Params(buyNow: true)
+    let data = try encoder.encode(params)
+    let paramsString = String(data: data, encoding: .utf8)
+    XCTAssertEqual(paramsString, "{\"buyNow\":true}")
+  }
+
+  func testDoesNotEncodeIfFalse() throws {
+    let encoder = JSONEncoder()
+
+    let params = Params(buyNow: false)
+    let data = try encoder.encode(params)
+    let paramsString = String(data: data, encoding: .utf8)
+    XCTAssertEqual(paramsString, "{}")
+  }
+}
+
+private extension KeyedEncodingContainerProtocolTests {
+  // swiftlint:disable nesting
+  struct Params: Encodable {
+    let buyNow: Bool
+
+    enum CodingKeys: CodingKey {
+      case buyNow
+    }
+
+    func encode(to encoder: any Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encodeIfTrue(self.buyNow, forKey: .buyNow)
+    }
+  }
+}

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -244,11 +244,7 @@ public func signCashAppOrderToken(
   completion: @escaping (_ result: CashAppSigningResult) -> Void
 ) {
 
-  guard
-    getConfiguration() != nil || getV3Configuration() != nil,
-    let cashAppSigningURL = getConfiguration()?.environment.cashAppSigningURL ??
-      getV3Configuration()?.environment.cashAppSigningURL
-  else {
+  guard let configuration = getConfiguration() else {
     return assertionFailure(
       "Configuration must be provided before using `signCashAppOrder`"
     )
@@ -258,13 +254,11 @@ public func signCashAppOrderToken(
     return
   }
 
-  let cashAppCheckout = CashAppPayCheckout(
+  CashAppPayCheckout.signCashAppOrderToken(
+    token,
+    cashAppSigningURL: configuration.environment.cashAppSigningURL,
     urlSession: urlSession,
-    cashAppSigningURL: cashAppSigningURL,
-    completion: completion
-  )
-
-  cashAppCheckout.signToken(token: token)
+    completion: completion)
 }
 
 public func validateCashAppOrder(
@@ -423,13 +417,15 @@ internal var brand: Brand {
 }
 
 public var enabled: Bool {
-  let enabledByV2Config = language != nil && getConfiguration()?.locale != nil
-  let enabledByV3Config = language != nil  && getV3Configuration()?.region == .US
-  return enabledByV2Config || enabledByV3Config
+  return language != nil && getConfiguration()?.locale != nil
 }
 
 public var cashAppClientId: String? {
   getConfiguration()?.environment.cashAppClientId
+}
+
+public var checkoutV3CashAppClientId: String? {
+  getV3Configuration()?.environment.cashAppClientId
 }
 
 public var environment: Environment? {

--- a/Sources/Afterpay/Afterpay.swift
+++ b/Sources/Afterpay/Afterpay.swift
@@ -243,7 +243,12 @@ public func signCashAppOrderToken(
   urlSession: URLSession = .shared,
   completion: @escaping (_ result: CashAppSigningResult) -> Void
 ) {
-  guard let configuration = getConfiguration() else {
+
+  guard
+    getConfiguration() != nil || getV3Configuration() != nil,
+    let cashAppSigningURL = getConfiguration()?.environment.cashAppSigningURL ??
+      getV3Configuration()?.environment.cashAppSigningURL
+  else {
     return assertionFailure(
       "Configuration must be provided before using `signCashAppOrder`"
     )
@@ -255,7 +260,7 @@ public func signCashAppOrderToken(
 
   let cashAppCheckout = CashAppPayCheckout(
     urlSession: urlSession,
-    configuration: configuration,
+    cashAppSigningURL: cashAppSigningURL,
     completion: completion
   )
 
@@ -418,7 +423,9 @@ internal var brand: Brand {
 }
 
 public var enabled: Bool {
-  return language != nil && getConfiguration()?.locale != nil
+  let enabledByV2Config = language != nil && getConfiguration()?.locale != nil
+  let enabledByV3Config = language != nil  && getV3Configuration()?.region == .US
+  return enabledByV2Config || enabledByV3Config
 }
 
 public var cashAppClientId: String? {

--- a/Sources/Afterpay/AfterpayV3.swift
+++ b/Sources/Afterpay/AfterpayV3.swift
@@ -242,7 +242,7 @@ public func presentCheckoutV3Modally(
 
 private var checkoutV3Configuration: CheckoutV3Configuration?
 
-public func setV3Configuration(_ configuration: CheckoutV3Configuration) {
+public func setV3Configuration(_ configuration: CheckoutV3Configuration?) {
   checkoutV3Configuration = configuration
 }
 

--- a/Sources/Afterpay/AfterpayV3.swift
+++ b/Sources/Afterpay/AfterpayV3.swift
@@ -48,7 +48,11 @@ public func checkoutV3WithCashAppPay(
   ) { checkoutResult in
     switch checkoutResult {
     case .success(let checkout):
-      signCashAppOrderToken(checkout.token, urlSession: urlSession) { signingResult in
+      CashAppPayCheckout.signCashAppOrderToken(
+        checkout.token,
+        cashAppSigningURL: configuration.environment.cashAppSigningURL,
+        urlSession: urlSession
+      ) { signingResult in
         switch signingResult {
         case .success(let signingData):
           let response = CheckoutV3CashAppPayPayload(

--- a/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
+++ b/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
@@ -264,4 +264,18 @@ internal extension CashAppPayCheckout {
       completion: completion
     ).resume()
   }
+
+  static func signCashAppOrderToken(
+    _ token: Token,
+    cashAppSigningURL: String,
+    urlSession: URLSession = .shared,
+    completion: @escaping (_ result: CashAppSigningResult) -> Void
+  ) {
+    let cashAppCheckout = CashAppPayCheckout(
+      urlSession: urlSession,
+      cashAppSigningURL: cashAppSigningURL,
+      completion: completion
+    )
+    cashAppCheckout.signToken(token: token)
+  }
 }

--- a/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
+++ b/Sources/Afterpay/CashApp/CashAppPayCheckout.swift
@@ -10,16 +10,16 @@ import Foundation
 
 class CashAppPayCheckout {
   private let urlSession: URLSession
-  private let configuration: Configuration
+  private let cashAppSigningURL: String
   private let completion: (_ result: CashAppSigningResult) -> Void
 
   public init(
     urlSession: URLSession,
-    configuration: Configuration,
+    cashAppSigningURL: String,
     completion: @escaping (_ result: CashAppSigningResult) -> Void
   ) {
     self.urlSession = urlSession
-    self.configuration = configuration
+    self.cashAppSigningURL = cashAppSigningURL
     self.completion = completion
   }
 
@@ -28,7 +28,7 @@ class CashAppPayCheckout {
     let jsonRequestBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
     guard let request = CashAppPayCheckout.createRequest(
-      urlString: configuration.environment.cashAppSigningURL,
+      urlString: cashAppSigningURL,
       jsonRequestBody: jsonRequestBody
     ) else {
       return assertionFailure("Could not create signing request when handling CashApp token")

--- a/Sources/Afterpay/Checkout/CheckoutV3.swift
+++ b/Sources/Afterpay/Checkout/CheckoutV3.swift
@@ -67,6 +67,37 @@ enum CheckoutV3 {
       self.isCashAppPay = isCashAppPay
     }
 
+    // MARK: - Encoding
+
+    enum CodingKeys: CodingKey {
+      case shopDirectoryId
+      case shopDirectoryMerchantId
+      case amount
+      case shippingAmount
+      case taxAmount
+      case items
+      case consumer
+      case merchant
+      case shipping
+      case billing
+      case isCashAppPay
+    }
+
+    func encode(to encoder: any Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(shopDirectoryId, forKey: .shopDirectoryId)
+      try container.encode(shopDirectoryMerchantId, forKey: .shopDirectoryMerchantId)
+      try container.encode(amount, forKey: .amount)
+      try container.encodeIfPresent(shippingAmount, forKey: .shippingAmount)
+      try container.encodeIfPresent(taxAmount, forKey: .taxAmount)
+      try container.encode(items, forKey: .items)
+      try container.encode(consumer, forKey: .consumer)
+      try container.encode(merchant, forKey: .merchant)
+      try container.encodeIfPresent(shipping, forKey: .shipping)
+      try container.encodeIfPresent(billing, forKey: .billing)
+      try container.encodeIfTrue(isCashAppPay, forKey: .isCashAppPay)
+    }
+
     // MARK: - Inner types
 
     struct Item: Encodable {

--- a/Sources/Afterpay/Helpers/KeyedEncodingContainerProtocol+Extensions.swift
+++ b/Sources/Afterpay/Helpers/KeyedEncodingContainerProtocol+Extensions.swift
@@ -1,0 +1,17 @@
+//
+//  KeyedEncodingContainerProtocol+Extensions.swift
+//  AfterpayTests
+//
+//  Created by Mark Mroz on 2024-06-16.
+//  Copyright © 2024 Afterpay. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encode the given value if it is true otherwise do nothing.
+  mutating func encodeIfTrue(_ value: Bool, forKey key: Key) throws {
+    guard value else { return }
+    try encode(value, forKey: key)
+  }
+}


### PR DESCRIPTION
This PR fixes a bug where merchants were required to set `Configuration` and `V3Configuration` for Afterpay with Cash App Pay.

Now merchants only need to set `V3Configuration`.