### PR TITLE
Use CheckoutV3 region for currency formatting

### DIFF
--- a/Sources/Afterpay/AfterpayV3.swift
+++ b/Sources/Afterpay/AfterpayV3.swift
@@ -347,18 +347,19 @@ public struct CheckoutV3Configuration {
       return currencyCode
     }
 
-    private static var formatter: NumberFormatter = {
-      var formatter = NumberFormatter()
+    private var formatter: NumberFormatter {
+      let formatter = NumberFormatter()
       formatter.numberStyle = .decimal
       // ISO 4217 specifies 2 decimal points
       formatter.maximumFractionDigits = 2
       formatter.roundingMode = .halfEven // Banker's rounding
       formatter.groupingSeparator = ""
+      formatter.locale = locale
       return formatter
-    }()
+    }
 
     func formatted(currency: Decimal) -> String {
-      return Self.formatter.string(from: currency as NSDecimalNumber)!
+      return formatter.string(from: currency as NSDecimalNumber)!
     }
   }
 }


### PR DESCRIPTION
Currently when using CheckoutV3 the cart totals are formatted using the locale of the device instead of the region set in CheckoutV3Configuration. This is causing the API to return errors for regions that format currency using commas instead of decimal points.

This PR fixes the issue by having the formatter respect the regional locale.