### PR TITLE
fix crash from using legacy UI from cashappafterpay locale

### DIFF
--- a/Example/Example/Components/ComponentsViewController.swift
+++ b/Example/Example/Components/ComponentsViewController.swift
@@ -215,6 +215,8 @@ private final class ContentStackViewController: UIViewController, PriceBreakdown
       priceBreakdown3.delegate = self
       priceBreakdown3.logoColorScheme = .dynamic(lightPalette: .darkMono, darkPalette: .lightMono)
       stack.addArrangedSubview(priceBreakdown3)
+      let b = BadgeView(colorScheme: .dynamic(lightPalette: .alt, darkPalette: .darkMono))
+      stack.addArrangedSubview(b)
     }
 
     let stackConstraints = [

--- a/Sources/Afterpay/Views/BadgeView.swift
+++ b/Sources/Afterpay/Views/BadgeView.swift
@@ -12,9 +12,12 @@ import UIKit
 public class BadgeView: AfterpayLogo {
   override public init(colorScheme: ColorScheme = .static(.default)) {
     if Afterpay.isCashAppAfterpayRegion {
-      assertionFailure("Cash App Afterpay badge is not supported")
+      #if DEBUG
+        assertionFailure("Cash App Afterpay compact badge is not supported")
+      #endif
     }
     super.init(colorScheme: colorScheme)
+    if Afterpay.isCashAppAfterpayRegion { self.isHidden = true }
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/Afterpay/Views/CompactBadgeView.swift
+++ b/Sources/Afterpay/Views/CompactBadgeView.swift
@@ -12,9 +12,12 @@ import UIKit
 public class CompactBadgeView: AfterpayLogo {
   override public init(colorScheme: ColorScheme = .static(.default)) {
     if Afterpay.isCashAppAfterpayRegion {
-      assertionFailure("Cash App Afterpay compact badge is not supported")
+      #if DEBUG
+        assertionFailure("Cash App Afterpay compact badge is not supported")
+      #endif
     }
     super.init(colorScheme: colorScheme)
+    if Afterpay.isCashAppAfterpayRegion { self.isHidden = true }
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/Afterpay/Views/LogoView.swift
+++ b/Sources/Afterpay/Views/LogoView.swift
@@ -72,17 +72,15 @@ public class AfterpayLogo: UIView {
     deactivateConstraints()
 
     let color = getImageColor()
-    image = AfterpayAssetProvider.image(named: getImageName(brand: brand.details.lowerCaseName, color: color))
-
-    ratio = image!.size.height / image!.size.width
-
-    imageView.image = image
-    imageView.translatesAutoresizingMaskIntoConstraints = false
-
-    addSubview(imageView)
-
-    setImageViewConstraints()
-    setupConstraints()
+    if let image = AfterpayAssetProvider.image(named: getImageName(brand: brand.details.lowerCaseName, color: color)) {
+      self.image = image
+      ratio = image.size.height / image.size.width
+      imageView.image = image
+      imageView.translatesAutoresizingMaskIntoConstraints = false
+      addSubview(imageView)
+      setImageViewConstraints()
+      setupConstraints()
+    }
   }
 
   internal func setImageViewConstraints() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-ios/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Previously we crashed if legacy UI was used in an unsupported region, here we just hide the UI to prevent crashes
-
-

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] Tests are included.
- [x] Documentation is changed or added.
