### PR TITLE
Add bug bounty and security docs

### DIFF
--- a/BUG-BOUNTY.md
+++ b/BUG-BOUNTY.md
@@ -1,0 +1,70 @@
+# Bug Bounty
+
+This repository participates in Block's Bug Bounty Program for open source projects.
+
+If you find a security vulnerability, please report it through our bug bounty program on Bugcrowd: https://bugcrowd.com/engagements/blockopensource
+
+## Rewards
+
+Bounties range from $100 to $5,000 depending on severity and impact:
+
+| Priority | Reward Range |
+|----------|--------------|
+| P1 | $2,500 - $5,000 |
+| P2 | $1,000 - $1,500 |
+| P3 | $250 - $500 |
+| P4 | $100 - $200 |
+
+## What's In Scope
+
+Only the latest release or main branch of this repository is eligible for rewards. We're looking for real security issues with actual exploitability - not just outdated dependencies or theoretical problems.
+
+Reports should include:
+- Clear proof-of-concept showing the vulnerability
+- Specific file and line references in the code
+- Description of the real-world impact
+- Steps to reproduce
+
+We won't accept reports for:
+- Old releases or development branches
+- Issues already publicly tracked or fixed
+- Problems without demonstrable exploitation
+- Outdated library versions alone (unless you can show actual impact)
+
+## How to Report
+
+**Don't open public issues or pull requests for security bugs.** That would reveal the vulnerability before we can fix it.
+
+Report through either:
+
+**GitHub Security Tab** (easier)
+- Go to the Security tab on this repo
+- Click "Report a vulnerability"  
+- Fill out the form
+
+**Bugcrowd** (for bounty tracking)
+- Submit at https://bugcrowd.com/engagements/blockopensource
+- Make sure to include repo name, version, and specific code references
+
+## Rules
+
+Read the [CONTRIBUTING.md](CONTRIBUTING.md) before you start testing.
+
+When testing:
+- Only test on your own local setup
+- If you access any real customer data, stop immediately and report it
+- Don't attempt DoS attacks
+- Keep your findings private until we've fixed the issue
+- Delete any sensitive data you found during testing
+
+**Important:** Don't use ChatGPT, Claude, DeepSeek, or any other AI tools during your security research. This protects both you and the data you might encounter.
+
+For questions or updates on your submission, contact support@bugcrowd.com - don't reach out to Block directly.
+
+## Submitting a Fix
+
+Have a fix for the vulnerability? Great! But don't open a public PR - that would expose the issue. Instead, include your fix in the private security advisory when you report it.
+
+## Safe Harbor
+
+We won't take legal action against researchers who follow these rules and report issues responsibly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security
+
+## Reporting Security Issues
+
+**Don't report security vulnerabilities through public issues or pull requests.**
+
+Found a security bug? Report it privately:
+
+1. **GitHub Security Tab** - Go to the Security tab and click "Report a vulnerability"
+2. **Bugcrowd** - Submit at https://bugcrowd.com/engagements/blockopensource
+
+Include:
+- Clear description and steps to reproduce
+- Which version is affected
+- Real-world impact
+
+### Bug Bounty
+
+Security vulnerabilities are eligible for rewards from $100 to $5,000. See [BUG-BOUNTY.md](BUG-BOUNTY.md) for details.
+
+### Response Time
+
+You'll typically hear back within 2-3 business days. Most submissions get reviewed within 10 days.
+
+## Supported Versions
+
+Only the latest release is eligible for bug bounty rewards.
+
+## For SDK Users
+
+If you're integrating this SDK into your app:
+
+- Keep the SDK updated
+- Don't log sensitive payment data
+- Use sandbox environment for testing
+- Store tokens securely using iOS Keychain
+
+## Contact
+
+Questions about bug bounty? Email support@bugcrowd.com
+
+Don't contact Block directly about security submissions.


### PR DESCRIPTION
As mentioned on bugcrowd, this two files are missing in this repo..

Proof: [https://bugcrowd.com/engagements/blockopensource]()

![IMG-20251019-WA0000](https://github.com/user-attachments/assets/66c34c69-9f01-4d9d-a318-daffc711025e)

Also I added a security documentation hope that will help more

So, I added those files, ready review and merge as suitable...