### PR TITLE
[COMSE-27] Example app: Cash App Pay on-file vs one-time grant mode toggle

### DIFF
--- a/Example/Example/Purchase/ButtonCashAppPayCheckout.swift
+++ b/Example/Example/Purchase/ButtonCashAppPayCheckout.swift
@@ -20,6 +20,19 @@ enum ButtonCashAppPayError: Error {
   case confirmation(error: Error)
 }
 
+/// Which Cash App Pay grant type to request when CAP runs through the Afterpay button.
+///
+/// Both modes hit the same Afterpay endpoints (`POST /v3/button`,
+/// `POST /v2/payments/sign-payment`, `POST /v3/button/confirm`); the only
+/// difference is the PayKit action attached to the customer request.
+enum CashAppPayMode {
+  /// PayKit `.oneTimePayment(scopeID:, money:)` — single-use authorization.
+  case oneTime
+  /// PayKit `.onFilePayment(scopeID:, accountReferenceID:)` — grant suitable
+  /// for storing on-file and re-charging via merchant-initiated transactions.
+  case onFile
+}
+
 protocol ButtonCashAppPayCheckoutDelegate: AnyObject {
   func didFinish(result: Result<ConfirmationV3.CashAppPayResponse, ButtonCashAppPayError>)
 }
@@ -31,6 +44,8 @@ final class ButtonCashAppPayCheckout {
   weak var delegate: ButtonCashAppPayCheckoutDelegate?
 
   // MARK: - Private Properties
+
+  private var mode: CashAppPayMode = .oneTime
 
   private lazy var paykit: CashAppPay? = {
     guard let clientId = Afterpay.cashAppClientId else {
@@ -62,34 +77,55 @@ final class ButtonCashAppPayCheckout {
 
   // MARK: - Private
 
-  func checkoutV3(consumer: Consumer, cartTotal: Decimal) {
+  func checkoutV3(consumer: Consumer, cartTotal: Decimal, mode: CashAppPayMode) {
+    self.mode = mode
+    NSLog("[CAP-AP] mode=\(mode) starting checkoutV3WithCashAppPay total=\(cartTotal)")
     Afterpay.checkoutV3WithCashAppPay(
       consumer: consumer,
       orderTotal: OrderTotal(total: cartTotal, shipping: .zero, tax: .zero)
     ) { [weak self] result in
       switch result {
       case .success(let data):
+        NSLog(
+          "[CAP-AP] checkoutV3 OK token=\(data.token) " +
+          "singleUseCardToken=\(data.singleUseCardToken) " +
+          "brandId=\(data.cashAppSigningData.brandId) " +
+          "amount=\(data.cashAppSigningData.amount) " +
+          "merchantId=\(data.cashAppSigningData.merchantId) " +
+          "jwt=\(data.cashAppSigningData.jwt)"
+        )
         self?.checkoutPayload = data
       case .cancelled(let reason):
+        NSLog("[CAP-AP] checkoutV3 CANCELLED reason=\(reason)")
         self?.delegate?.didFinish(result: .failure(.checkoutReason(reason)))
       case .failure(let error):
+        NSLog("[CAP-AP] checkoutV3 FAILED error=\(error)")
         self?.delegate?.didFinish(result: .failure(.checkout(error: error)))
       }
     }
   }
 
   private func createCustomerRequest(brandID: String, amount: UInt) {
+    // Both modes target the same Afterpay endpoints; only the PayKit action
+    // type changes. `.onFilePayment` carries no Money — the order amount is
+    // enforced server-side via the signed JWT supplied to `/v3/button/confirm`.
+    let action: PaymentAction
+    switch mode {
+    case .oneTime:
+      action = .oneTimePayment(
+        scopeID: brandID,
+        money: Money(amount: amount, currency: .USD)
+      )
+    case .onFile:
+      action = .onFilePayment(
+        scopeID: brandID,
+        accountReferenceID: nil
+      )
+    }
+    NSLog("[CAP-AP] createCustomerRequest mode=\(mode) brandId=\(brandID) action=\(action)")
     paykit?.createCustomerRequest(
       params: CreateCustomerRequestParams(
-        actions: [
-          .oneTimePayment(
-            scopeID: brandID,
-            money: Money(
-              amount: amount,
-              currency: .USD
-            )
-          ),
-        ],
+        actions: [action],
         redirectURL: URL(string: "aftersnack://callback")!,
         referenceID: nil,
         metadata: nil
@@ -102,6 +138,10 @@ final class ButtonCashAppPayCheckout {
   }
 
   private func confirmCheckout(grant: CustomerRequest.Grant) {
+    NSLog(
+      "[CAP-AP] confirmCheckout token=\(checkoutPayload.token) " +
+      "customerId=\(grant.customerID) grantId=\(grant.id)"
+    )
     Afterpay.checkoutV3ConfirmForCashAppPay(
       token: checkoutPayload.token,
       singleUseCardToken: checkoutPayload.singleUseCardToken,
@@ -110,8 +150,10 @@ final class ButtonCashAppPayCheckout {
       jwt: checkoutPayload.cashAppSigningData.jwt) { [weak self] result in
         switch result {
         case .success(let response):
+          NSLog("[CAP-AP] confirm OK paymentDetails=\(response.paymentDetails)")
           self?.delegate?.didFinish(result: .success(response))
         case .failure(let error):
+          NSLog("[CAP-AP] confirm FAILED error=\(error)")
           self?.delegate?.didFinish(result: .failure(.confirmation(error: error)))
         }
       }
@@ -122,6 +164,7 @@ final class ButtonCashAppPayCheckout {
 
 extension ButtonCashAppPayCheckout: CashAppPayObserver {
   func stateDidChange(to state: CashAppPayState) {
+    NSLog("[CAP-AP] PayKit state=\(state)")
     switch state {
     case .notStarted,
     .creatingCustomerRequest,
@@ -131,22 +174,32 @@ extension ButtonCashAppPayCheckout: CashAppPayObserver {
     .refreshing:
       break
     case .readyToAuthorize(let customerRequest):
+      NSLog("[CAP-AP] readyToAuthorize requestId=\(customerRequest.id)")
       authorizeCustomerRequest(customerRequest: customerRequest)
     case .declined:
+      NSLog("[CAP-AP] customer request DECLINED")
       delegate?.didFinish(result: .failure(.customerRequestDeclined))
-    case .approved(_, let grants):
+    case .approved(let request, let grants):
+      NSLog(
+        "[CAP-AP] customer request APPROVED requestId=\(request.id) " +
+        "grants=\(grants.map { "id=\($0.id) customerId=\($0.customerID) action=\($0.action)" })"
+      )
       if let grant = grants.first {
         self.grant = grant
       } else {
         delegate?.didFinish(result: .failure(.customerRequestMissingGrant))
       }
     case .apiError(let apiError):
+      NSLog("[CAP-AP] PayKit apiError=\(apiError)")
       delegate?.didFinish(result: .failure(.customerRequest(error: apiError)))
     case .integrationError(let integrationError):
+      NSLog("[CAP-AP] PayKit integrationError=\(integrationError)")
       delegate?.didFinish(result: .failure(.customerRequest(error: integrationError)))
     case .networkError(let networkError):
+      NSLog("[CAP-AP] PayKit networkError=\(networkError)")
       delegate?.didFinish(result: .failure(.customerRequest(error: networkError)))
     case .unexpectedError(let unexpectedError):
+      NSLog("[CAP-AP] PayKit unexpectedError=\(unexpectedError)")
       delegate?.didFinish(result: .failure(.customerRequest(error: unexpectedError)))
     }
   }

--- a/Example/Example/Purchase/CartViewController.swift
+++ b/Example/Example/Purchase/CartViewController.swift
@@ -24,8 +24,28 @@ final class CartViewController: UIViewController, UITableViewDataSource {
   }
 
   private lazy var cashAppButtonForV3 = CashAppPayButton(size: .large) { [weak self] in
-    self?.eventHandler(.didTapSingleUseCardButtonWithCashAppPay)
+    guard let self = self else { return }
+    let mode: CashAppPayMode = self.cashAppModeControl.selectedSegmentIndex == 0
+      ? .oneTime
+      : .onFile
+    self.eventHandler(.didTapSingleUseCardButtonWithCashAppPay(mode))
   }
+
+  private lazy var cashAppModeLabel: UILabel = {
+    let label = UILabel()
+    label.text = "Cash App Pay grant type"
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    label.textAlignment = .center
+    return label
+  }()
+
+  private lazy var cashAppModeControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: ["One-time", "On-file"])
+    control.selectedSegmentIndex = 0
+    control.accessibilityIdentifier = "cashAppPayMode"
+    return control
+  }()
 
   private var checkoutOption: CheckoutPickerOption = .v2 {
     didSet { updateViewState() }
@@ -37,7 +57,7 @@ final class CartViewController: UIViewController, UITableViewDataSource {
     case cartDidLoad(CashAppPayButton)
     case optionsChanged(CheckoutOptionsCell.Event)
     case didTapSingleUseCardButton
-    case didTapSingleUseCardButtonWithCashAppPay
+    case didTapSingleUseCardButtonWithCashAppPay(CashAppPayMode)
   }
 
   init(cart: CartDisplay, eventHandler: @escaping (Event) -> Void) {
@@ -80,12 +100,23 @@ final class CartViewController: UIViewController, UITableViewDataSource {
       cashButton.accessibilityIdentifier = "payWithCashApp"
       cashAppButtonForV3.accessibilityIdentifier = "payWithV3UsingCashApp"
 
-      let stack = UIStackView(arrangedSubviews: [payButton, cashButton, cashAppButtonForV3])
+      let cashAppModeStack = UIStackView(arrangedSubviews: [cashAppModeLabel, cashAppModeControl])
+      cashAppModeStack.axis = .vertical
+      cashAppModeStack.spacing = 4
+
+      let stack = UIStackView(arrangedSubviews: [
+        payButton, cashButton, cashAppModeStack, cashAppButtonForV3,
+      ])
       stack.axis = .vertical
+      stack.spacing = 8
       stack.isLayoutMarginsRelativeArrangement = true
       stack.directionalLayoutMargins = .init(top: 16, leading: 16, bottom: 8, trailing: 16)
       stack.translatesAutoresizingMaskIntoConstraints = false
       view.addSubview(stack)
+
+      // The mode picker only makes sense alongside the V3-CAP button.
+      cashAppModeLabel.isHidden = cashAppButtonForV3.isHidden
+      cashAppModeControl.isHidden = cashAppButtonForV3.isHidden
 
       NSLayoutConstraint.activate([
         stack.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -122,6 +153,8 @@ final class CartViewController: UIViewController, UITableViewDataSource {
   func updateViewState() {
     cashButton.isHidden = (checkoutOption == .v1 || checkoutOption == .v3)
     cashAppButtonForV3.isHidden = (checkoutOption == .v1 || checkoutOption == .v2)
+    cashAppModeLabel.isHidden = cashAppButtonForV3.isHidden
+    cashAppModeControl.isHidden = cashAppButtonForV3.isHidden
     eventHandler(.optionsChanged(.expressEnabled(checkoutOption == .v2)))
   }
 

--- a/Example/Example/Purchase/PurchaseFlowController.swift
+++ b/Example/Example/Purchase/PurchaseFlowController.swift
@@ -108,8 +108,8 @@ final class PurchaseFlowController: UIViewController {
           logicController.setExpressCheckoutEnabled(isEnabled)
         case .didTapSingleUseCardButton:
           logicController.payWithAfterpayV3()
-        case .didTapSingleUseCardButtonWithCashAppPay:
-          logicController.payWithAfterpayV3WithCashAppPay()
+        case .didTapSingleUseCardButtonWithCashAppPay(let mode):
+          logicController.payWithAfterpayV3WithCashAppPay(mode: mode)
         }
       }
 

--- a/Example/Example/Purchase/PurchaseLogicController.swift
+++ b/Example/Example/Purchase/PurchaseLogicController.swift
@@ -138,11 +138,12 @@ final class PurchaseLogicController {
     ))
   }
 
-  func payWithAfterpayV3WithCashAppPay() {
+  func payWithAfterpayV3WithCashAppPay(mode: CashAppPayMode) {
     buttonCashAppPayCheckout.delegate = self
     buttonCashAppPayCheckout.checkoutV3(
       consumer: Consumer(email: email),
-      cartTotal: buildCart().total
+      cartTotal: buildCart().total,
+      mode: mode
     )
   }
 


### PR DESCRIPTION
> 🚧 **Draft / WIP** — pushed to avoid losing work; not yet ready for review.

Linear: [COMSE-27](https://linear.app/squareup/issue/COMSE-27/sdk-ios-example-app-add-cash-app-pay-on-file-vs-one-time-grant-mode)

## Summary

Adds a *One-time* / *On-file* segmented control to the Example app's cart so the V3 Cash App Pay flow can request either PayKit grant type. Both modes hit the same Afterpay V3 CAP endpoints (`POST /v3/button`, `/v2/payments/sign-payment`, `/v3/button/confirm`); only the PayKit `PaymentAction` attached to the customer request differs:

- `.oneTimePayment(scopeID:, money:)` — current behavior, single-use authorization.
- `.onFilePayment(scopeID:, accountReferenceID:)` — grant suitable for on-file storage / merchant-initiated transactions.

This is purely Example-app plumbing for support / validation work — no changes to the public Afterpay SDK API.

## Changes

- **`Example/Example/Purchase/ButtonCashAppPayCheckout.swift`**
  - New `CashAppPayMode` enum (`.oneTime` / `.onFile`).
  - `checkoutV3(consumer:cartTotal:mode:)` stores the selected mode and threads it through `createCustomerRequest`, which now branches the `PaymentAction`.
  - `NSLog("[CAP-AP] …")` traces across `checkoutV3`, customer-request creation, PayKit state changes, approval, and `confirmCheckout`.
- **`Example/Example/Purchase/CartViewController.swift`**
  - `UISegmentedControl` ("One-time" / "On-file") above the V3-CAP button; hidden whenever the V3-CAP button is hidden.
  - New event payload `Event.didTapSingleUseCardButtonWithCashAppPay(CashAppPayMode)`.
- **`Example/Example/Purchase/PurchaseFlowController.swift`** / **`PurchaseLogicController.swift`**
  - Pass `mode` through to `payWithAfterpayV3WithCashAppPay(mode:)`.

## Out of scope

- Public SDK surface (`Afterpay.checkoutV3WithCashAppPay` / `checkoutV3ConfirmForCashAppPay`) is unchanged.
- Recurring/MIT capture flow (this PR only validates the grant; capture is server-side).

## Test plan (not yet executed)

- [ ] Run Example app, switch checkout option to V3, toggle mode = `One-time`, confirm Cash App Pay flow completes (existing path).
- [ ] Toggle mode = `On-file`, confirm PayKit returns an approved customer request whose `grant.action` is `onFilePayment` and that `/v3/button/confirm` succeeds.
- [ ] Inspect `[CAP-AP]` logs for both modes.
